### PR TITLE
improved alert account selector

### DIFF
--- a/components/AlertItem.tsx
+++ b/components/AlertItem.tsx
@@ -2,28 +2,17 @@ import { FunctionComponent } from 'react'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import styled from '@emotion/styled'
-import { PublicKey } from '@solana/web3.js'
 import { ClockIcon, DeviceMobileIcon, MailIcon } from '@heroicons/react/outline'
 import { TelegramIcon } from './icons'
 import { abbreviateAddress } from '../utils'
 import { LinkButton } from './Button'
+import { Alert } from '../stores/useAlertsStore'
 
 dayjs.extend(relativeTime)
 
 const StyledDiv = styled.div`
   font-size: 0.75rem;
 `
-
-type AlertProvider = 'mail' | 'sms' | 'tg'
-
-interface Alert {
-  acc: PublicKey
-  alertProvider: AlertProvider
-  collateralRatioThresh: number
-  open: boolean
-  timestamp: number
-  triggeredTimestamp: number | undefined
-}
 
 interface AlertItemProps {
   alert: Alert

--- a/components/AlertsModal.tsx
+++ b/components/AlertsModal.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent, useEffect, useState } from 'react'
+import { PublicKey } from '@solana/web3.js'
 import { RadioGroup } from '@headlessui/react'
 import {
   CheckCircleIcon,
@@ -20,9 +21,11 @@ import Loading from './Loading'
 import MarginAccountSelect from './MarginAccountSelect'
 import Tooltip from './Tooltip'
 import Select from './Select'
-import { PublicKey } from '@solana/web3.js'
 
 interface AlertsModalProps {
+  marginAccount?: {
+    publicKey: PublicKey
+  }
   alert?: {
     alertProvider: string
     collateralRatioThresh: number
@@ -36,6 +39,7 @@ const AlertsModal: FunctionComponent<AlertsModalProps> = ({
   isOpen,
   onClose,
   alert,
+  marginAccount,
 }) => {
   const connected = useMangoStore((s) => s.wallet.connected)
   const marginAccounts = useMangoStore((s) => s.marginAccounts)
@@ -46,7 +50,9 @@ const AlertsModal: FunctionComponent<AlertsModalProps> = ({
   const set = useAlertsStore((s) => s.set)
   const tgCode = useAlertsStore((s) => s.tgCode)
 
-  const [selectedMarginAccount, setSelectedMarginAccount] = useState<any>(null)
+  const [selectedMarginAccount, setSelectedMarginAccount] = useState<any>(
+    marginAccount || marginAccounts[0]
+  )
   const [collateralRatioPreset, setCollateralRatioPreset] = useState('113')
   const [customCollateralRatio, setCustomCollateralRatio] = useState('')
   const [alertProvider, setAlertProvider] = useState('sms')
@@ -171,7 +177,9 @@ const AlertsModal: FunctionComponent<AlertsModalProps> = ({
         <div className="flex flex-col items-center text-th-fgd-1">
           <CheckCircleIcon className="h-6 w-6 text-th-green mb-1" />
           <div className="font-bold text-lg pb-1">{success}</div>
-          <p className="text-center">We'll let you know if it's triggered.</p>
+          <p className="text-center">
+            {"We'll let you know if it's triggered."}
+          </p>
           <Button
             onClick={() => handleCloseSuccessView()}
             className="w-full mt-2"

--- a/components/AlertsModal.tsx
+++ b/components/AlertsModal.tsx
@@ -50,8 +50,12 @@ const AlertsModal: FunctionComponent<AlertsModalProps> = ({
   const set = useAlertsStore((s) => s.set)
   const tgCode = useAlertsStore((s) => s.tgCode)
 
+  // select by default:
+  // 1. margin account passed in directly (from the margin account info on the trade page)
+  // 2. previous alert's margin account (when re-activating from the alerts page)
+  // 3, the first margin account
   const [selectedMarginAccount, setSelectedMarginAccount] = useState<any>(
-    marginAccount || marginAccounts[0]
+    marginAccount || alert?.acc || marginAccounts[0]
   )
   const [collateralRatioPreset, setCollateralRatioPreset] = useState('113')
   const [customCollateralRatio, setCustomCollateralRatio] = useState('')

--- a/components/MarginInfo.tsx
+++ b/components/MarginInfo.tsx
@@ -183,6 +183,7 @@ export default function MarginInfo() {
           <AlertsModal
             isOpen={openAlertModal}
             onClose={() => setOpenAlertModal(false)}
+            marginAccount={selectedMarginAccount}
           />
         ) : null}
       </>

--- a/components/ThemeSwitch.tsx
+++ b/components/ThemeSwitch.tsx
@@ -3,7 +3,6 @@ import { useTheme } from 'next-themes'
 import { MoonIcon, SunIcon } from '@heroicons/react/outline'
 import DropMenu from './DropMenu'
 import { MangoIcon } from './icons'
-import Tooltip from './Tooltip'
 
 const THEMES = [
   { name: 'Light', icon: <SunIcon className="h-4 w-4" /> },

--- a/pages/alerts.tsx
+++ b/pages/alerts.tsx
@@ -19,7 +19,7 @@ import AlertItem from '../components/AlertItem'
 import PageBodyContainer from '../components/PageBodyContainer'
 import { abbreviateAddress } from '../utils'
 
-var relativeTime = require('dayjs/plugin/relativeTime')
+const relativeTime = require('dayjs/plugin/relativeTime')
 dayjs.extend(relativeTime)
 
 const TABS = ['Active', 'Triggered']

--- a/stores/useAlertsStore.tsx
+++ b/stores/useAlertsStore.tsx
@@ -3,9 +3,9 @@ import produce from 'immer'
 import { PublicKey } from '@solana/web3.js'
 import { notify } from '../utils/notifications'
 
-type AlertProvider = 'mail' | 'sms' | 'tg'
+export type AlertProvider = 'mail' | 'sms' | 'tg'
 
-interface Alert {
+export interface Alert {
   acc: PublicKey
   alertProvider: AlertProvider
   collateralRatioThresh: number
@@ -24,7 +24,6 @@ interface AlertRequest {
 }
 
 interface AlertsStore extends State {
-  alerts: Array<Alert>
   activeAlerts: Array<Alert>
   triggeredAlerts: Array<Alert>
   loading: boolean
@@ -78,10 +77,10 @@ const useAlertsStore = create<AlertsStore>((set, get) => ({
           return response.json()
         })
         .then((json: any) => {
-          const alerts = get().alerts
+          const alerts = get().activeAlerts
 
           set((state) => {
-            state.alerts = [alert as Alert].concat(alerts)
+            state.activeAlerts = [alert as Alert].concat(alerts)
             state.success = json.code ? '' : 'Alert saved successfully'
             state.tgCode = json.code
           })
@@ -160,20 +159,17 @@ const useAlertsStore = create<AlertsStore>((set, get) => ({
         accounts.alerts.forEach((alert) => (alert.acc = marginAccounts[index]))
       )
 
-      const flattenAccountAlerts = [].concat.apply(
-        [],
+      const flattenAccountAlerts = [].concat(
         responses.map((acc) => acc.alerts.map((alerts) => alerts))
       )
 
       const triggeredAlerts = flattenAccountAlerts
         .filter((alert) => !alert.open)
         .sort((a, b) => {
-          var aTriggeredTimestamp = a.hasOwnProperty('triggeredTimestamp')
-          var bTriggeredTimestamp = b.hasOwnProperty('triggeredTimestamp')
-          if (aTriggeredTimestamp && bTriggeredTimestamp) {
+          if (a.triggeredTimestamp && b.triggeredTimestamp) {
             return b.triggeredTimestamp - a.triggeredTimestamp
           }
-          return aTriggeredTimestamp ? -1 : bTriggeredTimestamp ? 1 : 0
+          return a.triggeredTimestamp ? -1 : b.triggeredTimestamp ? 1 : 0
         })
 
       const activeAlerts = flattenAccountAlerts.filter((alert) => alert.open)

--- a/stores/useAlertsStore.tsx
+++ b/stores/useAlertsStore.tsx
@@ -154,6 +154,7 @@ const useAlertsStore = create<AlertsStore>((set, get) => ({
       )
 
       // Add margin account address to alerts
+      // Assign triggeredTimestamp for old alerts in the DB that don't have this property yet
       responses.forEach((accounts, index) =>
         accounts.alerts.forEach((alert) => {
           alert.acc = marginAccounts[index]
@@ -165,12 +166,14 @@ const useAlertsStore = create<AlertsStore>((set, get) => ({
 
       const flattenAccountAlerts = responses.map((acc) => acc.alerts).flat()
 
+      // sort active by latest creation time first
       const activeAlerts = flattenAccountAlerts
         .filter((alert) => alert.open)
         .sort((a, b) => {
           return b.timestamp - a.timestamp
         })
 
+      // sort triggered by latest trigger time first
       const triggeredAlerts = flattenAccountAlerts
         .filter((alert) => !alert.open)
         .sort((a, b) => {

--- a/stores/useAlertsStore.tsx
+++ b/stores/useAlertsStore.tsx
@@ -36,7 +36,6 @@ interface AlertsStore extends State {
 }
 
 const useAlertsStore = create<AlertsStore>((set, get) => ({
-  alerts: [],
   activeAlerts: [],
   triggeredAlerts: [],
   loading: false,
@@ -156,23 +155,23 @@ const useAlertsStore = create<AlertsStore>((set, get) => ({
 
       // Add margin account address to alerts
       responses.forEach((accounts, index) =>
-        accounts.alerts.forEach((alert) => (alert.acc = marginAccounts[index]))
+        accounts.alerts.forEach((alert) => {
+          alert.acc = marginAccounts[index]
+          if (!alert.open) {
+            alert.triggeredTimestamp ||= alert.timestamp
+          }
+        })
       )
 
-      const flattenAccountAlerts = [].concat(
-        responses.map((acc) => acc.alerts.map((alerts) => alerts))
-      )
+      const flattenAccountAlerts = responses.map((acc) => acc.alerts).flat()
+
+      const activeAlerts = flattenAccountAlerts.filter((alert) => alert.open)
 
       const triggeredAlerts = flattenAccountAlerts
         .filter((alert) => !alert.open)
         .sort((a, b) => {
-          if (a.triggeredTimestamp && b.triggeredTimestamp) {
-            return b.triggeredTimestamp - a.triggeredTimestamp
-          }
-          return a.triggeredTimestamp ? -1 : b.triggeredTimestamp ? 1 : 0
+          return b.triggeredTimestamp - a.triggeredTimestamp
         })
-
-      const activeAlerts = flattenAccountAlerts.filter((alert) => alert.open)
 
       set((state) => {
         state.activeAlerts = activeAlerts

--- a/stores/useAlertsStore.tsx
+++ b/stores/useAlertsStore.tsx
@@ -165,7 +165,11 @@ const useAlertsStore = create<AlertsStore>((set, get) => ({
 
       const flattenAccountAlerts = responses.map((acc) => acc.alerts).flat()
 
-      const activeAlerts = flattenAccountAlerts.filter((alert) => alert.open)
+      const activeAlerts = flattenAccountAlerts
+        .filter((alert) => alert.open)
+        .sort((a, b) => {
+          return b.timestamp - a.timestamp
+        })
 
       const triggeredAlerts = flattenAccountAlerts
         .filter((alert) => !alert.open)


### PR DESCRIPTION
* previously i would sometimes get an error, when creating an alert, claiming there was no margin account selected
* automatically select same margin account the user was last trading with, when creating an alert