### PR TITLE
Balances table shows all assets in a mangoGroup

### DIFF
--- a/components/BalancesTable.tsx
+++ b/components/BalancesTable.tsx
@@ -5,8 +5,6 @@ import useConnection from '../hooks/useConnection'
 import Button from '../components/Button'
 import { notify } from '../utils/notifications'
 import { Table, Thead, Tbody, Tr, Th, Td } from 'react-super-responsive-table'
-import useMarket from '../hooks/useMarket'
-import { ElementTitle } from './styles'
 import { InformationCircleIcon } from '@heroicons/react/outline'
 import Tooltip from './Tooltip'
 import { sleep } from '../utils'
@@ -16,7 +14,6 @@ const BalancesTable = () => {
   const balances = useBalances()
   const { programId, connection } = useConnection()
   const actions = useMangoStore((s) => s.actions)
-  const { marketName } = useMarket()
 
   async function handleSettleAll() {
     const markets = Object.values(
@@ -58,11 +55,6 @@ const BalancesTable = () => {
     <div className={`flex flex-col py-6`}>
       <div className={`-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8`}>
         <div className={`align-middle inline-block min-w-full sm:px-6 lg:px-8`}>
-          <ElementTitle>
-            <div className="pr-1">{marketName.split('/')[0]}</div>
-            <span className="text-th-fgd-4">/</span>
-            <div className="pl-1">{marketName.split('/')[1]}</div>
-          </ElementTitle>
           {balances.length &&
           (balances.find(({ unsettled }) => unsettled > 0) ||
             balances.find(

--- a/hooks/useAllMarkets.tsx
+++ b/hooks/useAllMarkets.tsx
@@ -1,0 +1,39 @@
+import useConnection from './useConnection'
+import { IDS } from '@blockworks-foundation/mango-client'
+import useMangoStore from '../stores/useMangoStore'
+import { formatTokenMints } from './useMarket'
+
+const useAllMarkets = () => {
+  const markets = useMangoStore((s) => s.selectedMangoGroup.markets)
+  const { cluster, programId } = useConnection()
+  const TOKEN_MINTS = formatTokenMints(IDS[cluster].symbols)
+
+  return Object.keys(markets).map(function (marketIndex) {
+    const market = markets[marketIndex]
+    const marketAddress = market ? market.publicKey.toString() : null
+
+    const baseCurrency =
+      (market?.baseMintAddress &&
+        TOKEN_MINTS.find((token) =>
+          token.address.equals(market.baseMintAddress)
+        )?.name) ||
+      '...'
+
+    const quoteCurrency =
+      (market?.quoteMintAddress &&
+        TOKEN_MINTS.find((token) =>
+          token.address.equals(market.quoteMintAddress)
+        )?.name) ||
+      '...'
+
+    return {
+      market,
+      marketAddress,
+      programId,
+      baseCurrency,
+      quoteCurrency,
+    }
+  })
+}
+
+export default useAllMarkets

--- a/hooks/useBalances.tsx
+++ b/hooks/useBalances.tsx
@@ -1,4 +1,3 @@
-import useMarket from './useMarket'
 import { Balances } from '../@types/types'
 import { nativeToUi } from '@blockworks-foundation/mango-client'
 import useMarketList from './useMarketList'
@@ -8,108 +7,123 @@ import {
   displayDepositsForMarginAccount,
   floorToDecimal,
 } from '../utils'
+import useAllMarkets from './useAllMarkets'
 
 export function useBalances(): Balances[] {
-  const { baseCurrency, quoteCurrency, market } = useMarket()
+  let balances = []
+  const markets = useAllMarkets()
   const mangoGroup = useMangoStore((s) => s.selectedMangoGroup.current)
   const marginAccount = useMangoStore((s) => s.selectedMarginAccount.current)
   const { symbols } = useMarketList()
 
-  if (!marginAccount || !mangoGroup || !market) {
-    return []
-  }
+  for (const { market, baseCurrency, quoteCurrency } of markets) {
+    if (!marginAccount || !mangoGroup || !market) {
+      return []
+    }
 
-  const marketIndex = mangoGroup.getMarketIndex(market)
-  const openOrders: any = marginAccount.openOrdersAccounts[marketIndex]
-  const baseCurrencyIndex = Object.entries(symbols).findIndex(
-    (x) => x[0] === baseCurrency
-  )
-  const quoteCurrencyIndex = Object.entries(symbols).findIndex(
-    (x) => x[0] === quoteCurrency
-  )
-
-  if (
-    baseCurrency === 'UNKNOWN' ||
-    quoteCurrency === 'UNKNOWN' ||
-    !baseCurrency ||
-    !quoteCurrency
-  ) {
-    return []
-  }
-
-  const nativeBaseFree = openOrders?.baseTokenFree || 0
-  const nativeQuoteFree = openOrders?.quoteTokenFree || 0
-
-  const nativeBaseLocked = openOrders
-    ? openOrders.baseTokenTotal - nativeBaseFree
-    : 0
-  const nativeQuoteLocked = openOrders
-    ? openOrders?.quoteTokenTotal - nativeQuoteFree
-    : 0
-
-  const nativeBaseUnsettled = openOrders?.baseTokenFree || 0
-  const nativeQuoteUnsettled = openOrders?.quoteTokenFree || 0
-  const tokenIndex = marketIndex
-
-  const net = (borrows, currencyIndex) => {
-    const amount =
-      marginAccount.getNativeDeposit(mangoGroup, currencyIndex) +
-      borrows -
-      marginAccount.getNativeBorrow(mangoGroup, currencyIndex)
-
-    return floorToDecimal(
-      nativeToUi(amount, mangoGroup.mintDecimals[currencyIndex]),
-      mangoGroup.mintDecimals[currencyIndex]
+    const marketIndex = mangoGroup.getMarketIndex(market)
+    const openOrders: any = marginAccount.openOrdersAccounts[marketIndex]
+    const baseCurrencyIndex = Object.entries(symbols).findIndex(
+      (x) => x[0] === baseCurrency
     )
+    const quoteCurrencyIndex = Object.entries(symbols).findIndex(
+      (x) => x[0] === quoteCurrency
+    )
+
+    if (
+      baseCurrency === 'UNKNOWN' ||
+      quoteCurrency === 'UNKNOWN' ||
+      !baseCurrency ||
+      !quoteCurrency
+    ) {
+      return []
+    }
+
+    const nativeBaseFree = openOrders?.baseTokenFree || 0
+    const nativeQuoteFree = openOrders?.quoteTokenFree || 0
+
+    const nativeBaseLocked = openOrders
+      ? openOrders.baseTokenTotal - nativeBaseFree
+      : 0
+    const nativeQuoteLocked = openOrders
+      ? openOrders?.quoteTokenTotal - nativeQuoteFree
+      : 0
+
+    const nativeBaseUnsettled = openOrders?.baseTokenFree || 0
+    const nativeQuoteUnsettled = openOrders?.quoteTokenFree || 0
+    const tokenIndex = marketIndex
+
+    const net = (borrows, currencyIndex) => {
+      const amount =
+        marginAccount.getNativeDeposit(mangoGroup, currencyIndex) +
+        borrows -
+        marginAccount.getNativeBorrow(mangoGroup, currencyIndex)
+
+      return floorToDecimal(
+        nativeToUi(amount, mangoGroup.mintDecimals[currencyIndex]),
+        mangoGroup.mintDecimals[currencyIndex]
+      )
+    }
+
+    const marketPair = [
+      {
+        market,
+        key: `${baseCurrency}${quoteCurrency}${baseCurrency}`,
+        coin: baseCurrency,
+        marginDeposits: displayDepositsForMarginAccount(
+          marginAccount,
+          mangoGroup,
+          baseCurrencyIndex
+        ),
+        borrows: displayBorrowsForMarginAccount(
+          marginAccount,
+          mangoGroup,
+          baseCurrencyIndex
+        ),
+        orders: nativeToUi(
+          nativeBaseLocked,
+          mangoGroup.mintDecimals[tokenIndex]
+        ),
+        openOrders,
+        unsettled: nativeToUi(
+          nativeBaseUnsettled,
+          mangoGroup.mintDecimals[tokenIndex]
+        ),
+        net: net(nativeBaseLocked, tokenIndex),
+      },
+      {
+        market,
+        key: `${quoteCurrency}${baseCurrency}${quoteCurrency}`,
+        coin: quoteCurrency,
+        marginDeposits: displayDepositsForMarginAccount(
+          marginAccount,
+          mangoGroup,
+          quoteCurrencyIndex
+        ),
+        borrows: displayBorrowsForMarginAccount(
+          marginAccount,
+          mangoGroup,
+          quoteCurrencyIndex
+        ),
+        openOrders,
+        orders: nativeToUi(
+          nativeQuoteLocked,
+          mangoGroup.mintDecimals[quoteCurrencyIndex]
+        ),
+        unsettled: nativeToUi(
+          nativeQuoteUnsettled,
+          mangoGroup.mintDecimals[quoteCurrencyIndex]
+        ),
+        net: net(nativeQuoteLocked, quoteCurrencyIndex),
+      },
+    ]
+    balances = balances.concat(marketPair)
   }
 
-  return [
-    {
-      market,
-      key: `${baseCurrency}${quoteCurrency}${baseCurrency}`,
-      coin: baseCurrency,
-      marginDeposits: displayDepositsForMarginAccount(
-        marginAccount,
-        mangoGroup,
-        baseCurrencyIndex
-      ),
-      borrows: displayBorrowsForMarginAccount(
-        marginAccount,
-        mangoGroup,
-        baseCurrencyIndex
-      ),
-      orders: nativeToUi(nativeBaseLocked, mangoGroup.mintDecimals[tokenIndex]),
-      openOrders,
-      unsettled: nativeToUi(
-        nativeBaseUnsettled,
-        mangoGroup.mintDecimals[tokenIndex]
-      ),
-      net: net(nativeBaseLocked, tokenIndex),
-    },
-    {
-      market,
-      key: `${quoteCurrency}${baseCurrency}${quoteCurrency}`,
-      coin: quoteCurrency,
-      marginDeposits: displayDepositsForMarginAccount(
-        marginAccount,
-        mangoGroup,
-        quoteCurrencyIndex
-      ),
-      borrows: displayBorrowsForMarginAccount(
-        marginAccount,
-        mangoGroup,
-        quoteCurrencyIndex
-      ),
-      openOrders,
-      orders: nativeToUi(
-        nativeQuoteLocked,
-        mangoGroup.mintDecimals[quoteCurrencyIndex]
-      ),
-      unsettled: nativeToUi(
-        nativeQuoteUnsettled,
-        mangoGroup.mintDecimals[quoteCurrencyIndex]
-      ),
-      net: net(nativeQuoteLocked, quoteCurrencyIndex),
-    },
-  ]
+  balances.sort((a, b) => (a.coin > b.coin ? 1 : -1))
+  balances = balances.filter(function (elem, index, self) {
+    return index === self.map((a) => a.coin).indexOf(elem.coin)
+  })
+
+  return balances
 }

--- a/hooks/useMarket.tsx
+++ b/hooks/useMarket.tsx
@@ -4,7 +4,7 @@ import { PublicKey } from '@solana/web3.js'
 import useMangoStore from '../stores/useMangoStore'
 import { IDS } from '@blockworks-foundation/mango-client'
 
-const formatTokenMints = (symbols: { [name: string]: string }) => {
+export const formatTokenMints = (symbols: { [name: string]: string }) => {
   return Object.entries(symbols).map(([name, address]) => {
     return {
       address: new PublicKey(address),


### PR DESCRIPTION
Modifies the balances table to show every asset in a mangoGroup.

One alternative implementation could be to updating the useMarket hook like so:

const useMarket = (givenMarket? : Market) => {
  const market = givenMarket ?? useMangoStore((state) => state.selectedMarket.current)

This would result in a lot less code changed, however, I decided in favor of creating a new hook to explicitly use all markets since modifying the useMarket hook would break the convention that all hooks are parameterless, and it conditionally calls a React hook, which is not encouraged (https://reactjs.org/docs/hooks-rules.html).

Let me know what you think about this PR, I'm curious to see how it could be improved.