### PR TITLE
Trade form UI bugs

### DIFF
--- a/components/AccountSelect.tsx
+++ b/components/AccountSelect.tsx
@@ -184,7 +184,7 @@ const AccountSelect = ({
                 )
               })}
               {missingTokens && accounts.length !== 3 ? (
-                <Listbox.Option value="">
+                <Listbox.Option value="" disabled={true}>
                   <div className="flex items-center justify-center text-th-fgd-1 p-2">
                     Wallet token address not found for: {missingTokens}
                   </div>

--- a/components/BalancesTable.tsx
+++ b/components/BalancesTable.tsx
@@ -5,8 +5,6 @@ import useConnection from '../hooks/useConnection'
 import Button from '../components/Button'
 import { notify } from '../utils/notifications'
 import { Table, Thead, Tbody, Tr, Th, Td } from 'react-super-responsive-table'
-import useMarket from '../hooks/useMarket'
-import { ElementTitle } from './styles'
 import { InformationCircleIcon } from '@heroicons/react/outline'
 import Tooltip from './Tooltip'
 import { sleep } from '../utils'
@@ -16,7 +14,6 @@ const BalancesTable = () => {
   const balances = useBalances()
   const { programId, connection } = useConnection()
   const actions = useMangoStore((s) => s.actions)
-  const { marketName } = useMarket()
 
   async function handleSettleAll() {
     const markets = Object.values(
@@ -58,11 +55,6 @@ const BalancesTable = () => {
     <div className={`flex flex-col py-6`}>
       <div className={`-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8`}>
         <div className={`align-middle inline-block min-w-full sm:px-6 lg:px-8`}>
-          <ElementTitle>
-            <div className="pr-1">{marketName.split('/')[0]}</div>
-            <span className="text-th-fgd-4">/</span>
-            <div className="pl-1">{marketName.split('/')[1]}</div>
-          </ElementTitle>
           {balances.length &&
           (balances.find(({ unsettled }) => unsettled > 0) ||
             balances.find(

--- a/components/DepositModal.tsx
+++ b/components/DepositModal.tsx
@@ -1,25 +1,47 @@
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
+import { Disclosure } from '@headlessui/react'
+import {
+  ExclamationCircleIcon,
+  InformationCircleIcon,
+} from '@heroicons/react/outline'
+import {
+  ChevronLeftIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+} from '@heroicons/react/solid'
 import {
   nativeToUi,
   sleep,
 } from '@blockworks-foundation/mango-client/lib/utils'
+import { MarginAccount, uiToNative } from '@blockworks-foundation/mango-client'
 import Modal from './Modal'
 import Input from './Input'
 import AccountSelect from './AccountSelect'
 import { ElementTitle } from './styles'
 import useMangoStore from '../stores/useMangoStore'
 import useMarketList from '../hooks/useMarketList'
-import { getSymbolForTokenMintAddress } from '../utils/index'
+import {
+  getSymbolForTokenMintAddress,
+  DECIMALS,
+  trimDecimals,
+} from '../utils/index'
 import useConnection from '../hooks/useConnection'
 import { deposit, initMarginAccountAndDeposit } from '../utils/mango'
 import { PublicKey } from '@solana/web3.js'
 import Loading from './Loading'
-import Button from './Button'
+import Button, { LinkButton } from './Button'
+import Tooltip from './Tooltip'
+import Slider from './Slider'
 import { notify } from '../utils/notifications'
 
 const DepositModal = ({ isOpen, onClose }) => {
-  const [inputAmount, setInputAmount] = useState('')
+  const [inputAmount, setInputAmount] = useState(0)
   const [submitting, setSubmitting] = useState(false)
+  const [simulation, setSimulation] = useState(null)
+  const [showSimulation, setShowSimulation] = useState(false)
+  const [invalidAmountMessage, setInvalidAmountMessage] = useState('')
+  const [sliderPercentage, setSliderPercentage] = useState(0)
+  const [maxButtonTransition, setMaxButtonTransition] = useState(false)
   const { getTokenIndex, symbols } = useMarketList()
   const { connection, programId } = useConnection()
   const mintDecimals = useMangoStore((s) => s.selectedMangoGroup.mintDecimals)
@@ -34,9 +56,73 @@ const DepositModal = ({ isOpen, onClose }) => {
   )
   const [selectedAccount, setSelectedAccount] = useState(depositAccounts[0])
 
+  const prices = useMangoStore((s) => s.selectedMangoGroup.prices)
+  const selectedMangoGroup = useMangoStore((s) => s.selectedMangoGroup.current)
+  const selectedMarginAccount = useMangoStore(
+    (s) => s.selectedMarginAccount.current
+  )
+  const mintAddress = useMemo(
+    () => selectedAccount?.account.mint.toString(),
+    [selectedAccount]
+  )
+  const tokenIndex = useMemo(
+    () => getTokenIndex(mintAddress),
+    [mintAddress, getTokenIndex]
+  )
+  const symbol = getSymbolForTokenMintAddress(
+    selectedAccount?.account?.mint.toString()
+  )
+
+  useEffect(() => {
+    if (!selectedMangoGroup || !selectedMarginAccount) return
+
+    const mintDecimals = selectedMangoGroup.mintDecimals[tokenIndex]
+    const groupIndex = selectedMangoGroup.indexes[tokenIndex]
+    const deposits = selectedMarginAccount.getUiDeposit(
+      selectedMangoGroup,
+      tokenIndex
+    )
+
+    // simulate change to deposits based on input amount
+    const newDeposit = Math.max(0, +inputAmount + +deposits)
+
+    // clone MarginAccount and arrays to not modify selectedMarginAccount
+    const simulation = new MarginAccount(null, selectedMarginAccount)
+    simulation.deposits = [...selectedMarginAccount.deposits]
+    simulation.borrows = [...selectedMarginAccount.borrows]
+
+    // update with simulated values
+    simulation.deposits[tokenIndex] =
+      uiToNative(newDeposit, mintDecimals).toNumber() / groupIndex.deposit
+
+    const equity = simulation.computeValue(selectedMangoGroup, prices)
+    const assetsVal = simulation.getAssetsVal(selectedMangoGroup, prices)
+    const liabsVal = simulation.getLiabsVal(selectedMangoGroup, prices)
+    const collateralRatio = simulation.getCollateralRatio(
+      selectedMangoGroup,
+      prices
+    )
+    const leverage = 1 / Math.max(0, collateralRatio - 1)
+    setSimulation({
+      equity,
+      assetsVal,
+      liabsVal,
+      collateralRatio,
+      leverage,
+    })
+  }, [
+    inputAmount,
+    prices,
+    tokenIndex,
+    selectedMarginAccount,
+    selectedMangoGroup,
+  ])
+
   const handleAccountSelect = (account) => {
+    setInputAmount(0)
+    setSliderPercentage(0)
+    setInvalidAmountMessage('')
     setSelectedAccount(account)
-    setInputAmount('')
   }
 
   // TODO: remove duplication in AccountSelect
@@ -47,12 +133,15 @@ const DepositModal = ({ isOpen, onClose }) => {
       mintDecimals[getTokenIndex(mintAddress)]
     )
 
-    return balance.toString()
+    return balance
   }
 
   const setMaxForSelectedAccount = () => {
     const max = getBalanceForAccount(selectedAccount)
     setInputAmount(max)
+    setSliderPercentage(100)
+    setInvalidAmountMessage('')
+    setMaxButtonTransition(true)
   }
 
   const handleDeposit = () => {
@@ -118,55 +207,284 @@ const DepositModal = ({ isOpen, onClose }) => {
     }
   }
 
+  const renderAccountRiskStatus = (
+    collateralRatio: number,
+    isRiskLevel?: boolean,
+    isStatusIcon?: boolean
+  ) => {
+    if (collateralRatio < 1.25) {
+      return isRiskLevel ? (
+        <div className="text-th-red">High</div>
+      ) : isStatusIcon ? (
+        'bg-th-red'
+      ) : (
+        'border-th-red text-th-red'
+      )
+    } else if (collateralRatio > 1.25 && collateralRatio < 1.5) {
+      return isRiskLevel ? (
+        <div className="text-th-orange">Moderate</div>
+      ) : isStatusIcon ? (
+        'bg-th-orange'
+      ) : (
+        'border-th-orange text-th-orange'
+      )
+    } else {
+      return isRiskLevel ? (
+        <div className="text-th-green">Low</div>
+      ) : isStatusIcon ? (
+        'bg-th-green'
+      ) : (
+        'border-th-green text-th-green'
+      )
+    }
+  }
+
+  const validateAmountInput = (e) => {
+    const amount = e.target.value
+    if (Number(amount) <= 0) {
+      setInvalidAmountMessage('Enter an amount to deposit')
+    }
+    if (Number(amount) > getBalanceForAccount(selectedAccount)) {
+      setInvalidAmountMessage(
+        'Insufficient balance. Reduce the amount to deposit'
+      )
+    }
+  }
+
+  const onChangeAmountInput = (amount) => {
+    const max = getBalanceForAccount(selectedAccount)
+    setInputAmount(amount)
+    setSliderPercentage((amount / max) * 100)
+    setInvalidAmountMessage('')
+  }
+
+  const onChangeSlider = async (percentage) => {
+    const max = getBalanceForAccount(selectedAccount)
+    const amount = (percentage / 100) * max
+    setInputAmount(trimDecimals(amount, DECIMALS[symbol]))
+    setSliderPercentage(percentage)
+    setInvalidAmountMessage('')
+  }
+
+  // turn off slider transition for dragging slider handle interaction
+  useEffect(() => {
+    if (maxButtonTransition) {
+      setMaxButtonTransition(false)
+    }
+  }, [maxButtonTransition])
+
+  if (!selectedAccount) return null
+
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
-      <Modal.Header>
-        <div className={`text-th-fgd-3 flex-shrink invisible w-5`}>X</div>
-        <ElementTitle noMarignBottom>Deposit Funds</ElementTitle>
-      </Modal.Header>
-      <>
-        <AccountSelect
-          symbols={symbols}
-          accounts={depositAccounts}
-          selectedAccount={selectedAccount}
-          onSelectAccount={handleAccountSelect}
-        />
-        <div className="flex justify-between pb-2 pt-4">
-          <div className={`text-th-fgd-1`}>Amount</div>
-          <div
-            className="text-th-fgd-1 underline cursor-pointer default-transition hover:text-th-primary hover:no-underline"
-            onClick={setMaxForSelectedAccount}
-          >
-            Max
-          </div>
-        </div>
-        <div className="flex items-center">
-          <Input
-            type="number"
-            min="0"
-            className={`border border-th-fgd-4 flex-grow pr-11`}
-            placeholder="0.00"
-            value={inputAmount}
-            onChange={(e) => setInputAmount(e.target.value)}
-            suffix={getSymbolForTokenMintAddress(
-              selectedAccount?.account?.mint.toString()
-            )}
-          />
-        </div>
-        <div className={`mt-5 flex justify-center`}>
-          <Button onClick={handleDeposit} className="w-full">
-            <div className={`flex items-center justify-center`}>
-              {submitting && <Loading className="-ml-1 mr-3" />}
-              {`Deposit ${
-                inputAmount ? inputAmount : ''
-              } ${getSymbolForTokenMintAddress(
-                selectedAccount?.account?.mint.toString()
-              )}
-              `}
-            </div>
-          </Button>
-        </div>
-      </>
+      {simulation ? (
+        <>
+          {!showSimulation ? (
+            <>
+              <Modal.Header>
+                <div className={`text-th-fgd-3 flex-shrink invisible w-5`}>
+                  X
+                </div>
+                <ElementTitle noMarignBottom>Deposit Funds</ElementTitle>
+              </Modal.Header>
+              <AccountSelect
+                symbols={symbols}
+                accounts={depositAccounts}
+                selectedAccount={selectedAccount}
+                onSelectAccount={handleAccountSelect}
+              />
+              <div className="flex justify-between pb-2 pt-4">
+                <div className={`text-th-fgd-1`}>Amount</div>
+                <div
+                  className="text-th-fgd-1 underline cursor-pointer default-transition hover:text-th-primary hover:no-underline"
+                  onClick={setMaxForSelectedAccount}
+                >
+                  Max
+                </div>
+              </div>
+              <div className="flex">
+                <Input
+                  type="number"
+                  min="0"
+                  className={`border border-th-fgd-4 flex-grow pr-11`}
+                  placeholder="0.00"
+                  error={!!invalidAmountMessage}
+                  onBlur={validateAmountInput}
+                  value={inputAmount}
+                  onChange={(e) => onChangeAmountInput(e.target.value)}
+                  suffix={symbol}
+                />
+                <Tooltip content="Account Leverage" className="py-1">
+                  <span
+                    className={`${renderAccountRiskStatus(
+                      simulation.collateralRatio
+                    )} bg-th-bkg-1 border flex font-semibold h-10 items-center justify-center ml-2 rounded text-th-fgd-1 w-14`}
+                  >
+                    {simulation.leverage < 5
+                      ? simulation.leverage.toFixed(2)
+                      : '>5'}
+                    x
+                  </span>
+                </Tooltip>
+              </div>
+              {invalidAmountMessage ? (
+                <div className="flex items-center pt-1.5 text-th-red">
+                  <ExclamationCircleIcon className="h-4 w-4 mr-1.5" />
+                  {invalidAmountMessage}
+                </div>
+              ) : null}
+              <div className="pt-3 pb-4">
+                <Slider
+                  disabled={null}
+                  value={sliderPercentage}
+                  onChange={(v) => onChangeSlider(v)}
+                  step={1}
+                  maxButtonTransition={maxButtonTransition}
+                />
+              </div>
+              <div className={`mt-5 flex justify-center`}>
+                <Button
+                  onClick={() => setShowSimulation(true)}
+                  className="w-full"
+                  disabled={
+                    inputAmount <= 0 ||
+                    inputAmount > getBalanceForAccount(selectedAccount)
+                  }
+                >
+                  Next
+                </Button>
+              </div>
+            </>
+          ) : (
+            <>
+              <Modal.Header>
+                <ElementTitle noMarignBottom>Confirm Deposit</ElementTitle>
+              </Modal.Header>
+              <div className="bg-th-bkg-1 p-4 rounded-lg text-th-fgd-1 text-center">
+                <div className="text-th-fgd-3 pb-1">{`You're about to deposit`}</div>
+                <div className="flex items-center justify-center">
+                  <div className="font-semibold relative text-xl">
+                    {inputAmount}
+                    <span className="absolute bottom-0.5 font-normal ml-1.5 text-xs text-th-fgd-4">
+                      {symbol}
+                    </span>
+                  </div>
+                </div>
+              </div>
+              <Disclosure>
+                {({ open }) => (
+                  <>
+                    <Disclosure.Button
+                      className={`border border-th-fgd-4 default-transition font-normal mt-4 pl-3 pr-2 py-2.5 ${
+                        open ? 'rounded-b-none' : 'rounded-md'
+                      } text-th-fgd-1 w-full hover:bg-th-bkg-3 focus:outline-none`}
+                    >
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center">
+                          <span className="flex h-2 w-2 mr-2.5 relative">
+                            <span
+                              className={`animate-ping absolute inline-flex h-full w-full rounded-full ${renderAccountRiskStatus(
+                                simulation.collateralRatio,
+                                false,
+                                true
+                              )} opacity-75`}
+                            ></span>
+                            <span
+                              className={`relative inline-flex rounded-full h-2 w-2 ${renderAccountRiskStatus(
+                                simulation.collateralRatio,
+                                false,
+                                true
+                              )}`}
+                            ></span>
+                          </span>
+                          Account Health Check
+                          <Tooltip content="The details of your account after this deposit.">
+                            <InformationCircleIcon
+                              className={`h-5 w-5 ml-2 text-th-fgd-3 cursor-help`}
+                            />
+                          </Tooltip>
+                        </div>
+                        {open ? (
+                          <ChevronUpIcon className="h-5 w-5 mr-1" />
+                        ) : (
+                          <ChevronDownIcon className="h-5 w-5 mr-1" />
+                        )}
+                      </div>
+                    </Disclosure.Button>
+                    <Disclosure.Panel
+                      className={`border border-th-fgd-4 border-t-0 p-4 rounded-b-md`}
+                    >
+                      <div>
+                        <div className="flex justify-between pb-2">
+                          <div className="text-th-fgd-4">Account Value</div>
+                          <div className="text-th-fgd-1">
+                            ${simulation.assetsVal.toFixed(2)}
+                          </div>
+                        </div>
+                        <div className="flex justify-between pb-2">
+                          <div className="text-th-fgd-4">Account Risk</div>
+                          <div className="text-th-fgd-1">
+                            {renderAccountRiskStatus(
+                              simulation.collateralRatio,
+                              true
+                            )}
+                          </div>
+                        </div>
+                        <div className="flex justify-between pb-2">
+                          <div className="text-th-fgd-4">Leverage</div>
+                          <div className="text-th-fgd-1">
+                            {simulation.leverage.toFixed(2)}x
+                          </div>
+                        </div>
+                        <div className="flex justify-between">
+                          <div className="text-th-fgd-4">Collateral Ratio</div>
+                          <div className="text-th-fgd-1">
+                            {simulation.collateralRatio * 100 < 200
+                              ? Math.floor(simulation.collateralRatio * 100)
+                              : '>200'}
+                            %
+                          </div>
+                        </div>
+                        {simulation.liabsVal > 0.05 ? (
+                          <div className="flex justify-between pt-2">
+                            <div className="text-th-fgd-4">Borrow Value</div>
+                            <div className="text-th-fgd-1">
+                              ${simulation.liabsVal.toFixed(2)}
+                            </div>
+                          </div>
+                        ) : null}
+                      </div>
+                    </Disclosure.Panel>
+                  </>
+                )}
+              </Disclosure>
+              <div className={`mt-5 flex justify-center`}>
+                <Button onClick={handleDeposit} className="w-full">
+                  <div className={`flex items-center justify-center`}>
+                    {submitting && <Loading className="-ml-1 mr-3" />}
+                    Confirm
+                  </div>
+                </Button>
+              </div>
+              <LinkButton
+                className="flex items-center mt-4 text-th-fgd-3"
+                onClick={() => setShowSimulation(false)}
+              >
+                <ChevronLeftIcon className="h-5 w-5 mr-1" />
+                Back
+              </LinkButton>
+            </>
+          )}
+        </>
+      ) : (
+        <>
+          <div className="animate-pulse bg-th-bkg-3 h-10 mb-4 rounded w-full" />
+          <div className="animate-pulse bg-th-bkg-3 h-10 mb-4 rounded w-full" />
+          <div className="animate-pulse bg-th-bkg-3 h-10 mb-4 rounded w-full" />
+          <div className="animate-pulse bg-th-bkg-3 h-10 mb-4 rounded w-full" />
+          <div className="animate-pulse bg-th-bkg-3 h-10 mb-4 rounded w-full" />
+        </>
+      )}
     </Modal>
   )
 }

--- a/components/DepositModal.tsx
+++ b/components/DepositModal.tsx
@@ -273,216 +273,204 @@ const DepositModal = ({ isOpen, onClose }) => {
     }
   }, [maxButtonTransition])
 
-  if (!selectedAccount) return null
-
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
-      {simulation ? (
+      {!showSimulation ? (
         <>
-          {!showSimulation ? (
-            <>
-              <Modal.Header>
-                <div className={`text-th-fgd-3 flex-shrink invisible w-5`}>
-                  X
-                </div>
-                <ElementTitle noMarignBottom>Deposit Funds</ElementTitle>
-              </Modal.Header>
-              <AccountSelect
-                symbols={symbols}
-                accounts={depositAccounts}
-                selectedAccount={selectedAccount}
-                onSelectAccount={handleAccountSelect}
-              />
-              <div className="flex justify-between pb-2 pt-4">
-                <div className={`text-th-fgd-1`}>Amount</div>
-                <div
-                  className="text-th-fgd-1 underline cursor-pointer default-transition hover:text-th-primary hover:no-underline"
-                  onClick={setMaxForSelectedAccount}
+          <Modal.Header>
+            <div className={`text-th-fgd-3 flex-shrink invisible w-5`}>X</div>
+            <ElementTitle noMarignBottom>Deposit Funds</ElementTitle>
+          </Modal.Header>
+          <AccountSelect
+            symbols={symbols}
+            accounts={depositAccounts}
+            selectedAccount={selectedAccount}
+            onSelectAccount={handleAccountSelect}
+          />
+          <div className="flex justify-between pb-2 pt-4">
+            <div className={`text-th-fgd-1`}>Amount</div>
+            <div
+              className="text-th-fgd-1 underline cursor-pointer default-transition hover:text-th-primary hover:no-underline"
+              onClick={setMaxForSelectedAccount}
+            >
+              Max
+            </div>
+          </div>
+          <div className="flex">
+            <Input
+              type="number"
+              min="0"
+              className={`border border-th-fgd-4 flex-grow pr-11`}
+              placeholder="0.00"
+              error={!!invalidAmountMessage}
+              onBlur={validateAmountInput}
+              value={inputAmount}
+              onChange={(e) => onChangeAmountInput(e.target.value)}
+              suffix={symbol}
+            />
+            {simulation ? (
+              <Tooltip content="Account Leverage" className="py-1">
+                <span
+                  className={`${renderAccountRiskStatus(
+                    simulation?.collateralRatio
+                  )} bg-th-bkg-1 border flex font-semibold h-10 items-center justify-center ml-2 rounded text-th-fgd-1 w-14`}
                 >
-                  Max
-                </div>
-              </div>
-              <div className="flex">
-                <Input
-                  type="number"
-                  min="0"
-                  className={`border border-th-fgd-4 flex-grow pr-11`}
-                  placeholder="0.00"
-                  error={!!invalidAmountMessage}
-                  onBlur={validateAmountInput}
-                  value={inputAmount}
-                  onChange={(e) => onChangeAmountInput(e.target.value)}
-                  suffix={symbol}
-                />
-                <Tooltip content="Account Leverage" className="py-1">
-                  <span
-                    className={`${renderAccountRiskStatus(
-                      simulation.collateralRatio
-                    )} bg-th-bkg-1 border flex font-semibold h-10 items-center justify-center ml-2 rounded text-th-fgd-1 w-14`}
-                  >
-                    {simulation.leverage < 5
-                      ? simulation.leverage.toFixed(2)
-                      : '>5'}
-                    x
-                  </span>
-                </Tooltip>
-              </div>
-              {invalidAmountMessage ? (
-                <div className="flex items-center pt-1.5 text-th-red">
-                  <ExclamationCircleIcon className="h-4 w-4 mr-1.5" />
-                  {invalidAmountMessage}
-                </div>
-              ) : null}
-              <div className="pt-3 pb-4">
-                <Slider
-                  disabled={null}
-                  value={sliderPercentage}
-                  onChange={(v) => onChangeSlider(v)}
-                  step={1}
-                  maxButtonTransition={maxButtonTransition}
-                />
-              </div>
-              <div className={`mt-5 flex justify-center`}>
-                <Button
-                  onClick={() => setShowSimulation(true)}
-                  className="w-full"
-                  disabled={
-                    inputAmount <= 0 ||
-                    inputAmount > getBalanceForAccount(selectedAccount)
-                  }
-                >
-                  Next
-                </Button>
-              </div>
-            </>
-          ) : (
-            <>
-              <Modal.Header>
-                <ElementTitle noMarignBottom>Confirm Deposit</ElementTitle>
-              </Modal.Header>
-              <div className="bg-th-bkg-1 p-4 rounded-lg text-th-fgd-1 text-center">
-                <div className="text-th-fgd-3 pb-1">{`You're about to deposit`}</div>
-                <div className="flex items-center justify-center">
-                  <div className="font-semibold relative text-xl">
-                    {inputAmount}
-                    <span className="absolute bottom-0.5 font-normal ml-1.5 text-xs text-th-fgd-4">
-                      {symbol}
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <Disclosure>
-                {({ open }) => (
-                  <>
-                    <Disclosure.Button
-                      className={`border border-th-fgd-4 default-transition font-normal mt-4 pl-3 pr-2 py-2.5 ${
-                        open ? 'rounded-b-none' : 'rounded-md'
-                      } text-th-fgd-1 w-full hover:bg-th-bkg-3 focus:outline-none`}
-                    >
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center">
-                          <span className="flex h-2 w-2 mr-2.5 relative">
-                            <span
-                              className={`animate-ping absolute inline-flex h-full w-full rounded-full ${renderAccountRiskStatus(
-                                simulation.collateralRatio,
-                                false,
-                                true
-                              )} opacity-75`}
-                            ></span>
-                            <span
-                              className={`relative inline-flex rounded-full h-2 w-2 ${renderAccountRiskStatus(
-                                simulation.collateralRatio,
-                                false,
-                                true
-                              )}`}
-                            ></span>
-                          </span>
-                          Account Health Check
-                          <Tooltip content="The details of your account after this deposit.">
-                            <InformationCircleIcon
-                              className={`h-5 w-5 ml-2 text-th-fgd-3 cursor-help`}
-                            />
-                          </Tooltip>
-                        </div>
-                        {open ? (
-                          <ChevronUpIcon className="h-5 w-5 mr-1" />
-                        ) : (
-                          <ChevronDownIcon className="h-5 w-5 mr-1" />
-                        )}
-                      </div>
-                    </Disclosure.Button>
-                    <Disclosure.Panel
-                      className={`border border-th-fgd-4 border-t-0 p-4 rounded-b-md`}
-                    >
-                      <div>
-                        <div className="flex justify-between pb-2">
-                          <div className="text-th-fgd-4">Account Value</div>
-                          <div className="text-th-fgd-1">
-                            ${simulation.assetsVal.toFixed(2)}
-                          </div>
-                        </div>
-                        <div className="flex justify-between pb-2">
-                          <div className="text-th-fgd-4">Account Risk</div>
-                          <div className="text-th-fgd-1">
-                            {renderAccountRiskStatus(
-                              simulation.collateralRatio,
-                              true
-                            )}
-                          </div>
-                        </div>
-                        <div className="flex justify-between pb-2">
-                          <div className="text-th-fgd-4">Leverage</div>
-                          <div className="text-th-fgd-1">
-                            {simulation.leverage.toFixed(2)}x
-                          </div>
-                        </div>
-                        <div className="flex justify-between">
-                          <div className="text-th-fgd-4">Collateral Ratio</div>
-                          <div className="text-th-fgd-1">
-                            {simulation.collateralRatio * 100 < 200
-                              ? Math.floor(simulation.collateralRatio * 100)
-                              : '>200'}
-                            %
-                          </div>
-                        </div>
-                        {simulation.liabsVal > 0.05 ? (
-                          <div className="flex justify-between pt-2">
-                            <div className="text-th-fgd-4">Borrow Value</div>
-                            <div className="text-th-fgd-1">
-                              ${simulation.liabsVal.toFixed(2)}
-                            </div>
-                          </div>
-                        ) : null}
-                      </div>
-                    </Disclosure.Panel>
-                  </>
-                )}
-              </Disclosure>
-              <div className={`mt-5 flex justify-center`}>
-                <Button onClick={handleDeposit} className="w-full">
-                  <div className={`flex items-center justify-center`}>
-                    {submitting && <Loading className="-ml-1 mr-3" />}
-                    Confirm
-                  </div>
-                </Button>
-              </div>
-              <LinkButton
-                className="flex items-center mt-4 text-th-fgd-3"
-                onClick={() => setShowSimulation(false)}
-              >
-                <ChevronLeftIcon className="h-5 w-5 mr-1" />
-                Back
-              </LinkButton>
-            </>
-          )}
+                  {simulation?.leverage < 5
+                    ? simulation?.leverage.toFixed(2)
+                    : '>5'}
+                  x
+                </span>
+              </Tooltip>
+            ) : null}
+          </div>
+          {invalidAmountMessage ? (
+            <div className="flex items-center pt-1.5 text-th-red">
+              <ExclamationCircleIcon className="h-4 w-4 mr-1.5" />
+              {invalidAmountMessage}
+            </div>
+          ) : null}
+          <div className="pt-3 pb-4">
+            <Slider
+              disabled={null}
+              value={sliderPercentage}
+              onChange={(v) => onChangeSlider(v)}
+              step={1}
+              maxButtonTransition={maxButtonTransition}
+            />
+          </div>
+          <div className={`mt-5 flex justify-center`}>
+            <Button
+              onClick={() => setShowSimulation(true)}
+              className="w-full"
+              disabled={
+                inputAmount <= 0 ||
+                inputAmount > getBalanceForAccount(selectedAccount)
+              }
+            >
+              Next
+            </Button>
+          </div>
         </>
       ) : (
         <>
-          <div className="animate-pulse bg-th-bkg-3 h-10 mb-4 rounded w-full" />
-          <div className="animate-pulse bg-th-bkg-3 h-10 mb-4 rounded w-full" />
-          <div className="animate-pulse bg-th-bkg-3 h-10 mb-4 rounded w-full" />
-          <div className="animate-pulse bg-th-bkg-3 h-10 mb-4 rounded w-full" />
-          <div className="animate-pulse bg-th-bkg-3 h-10 mb-4 rounded w-full" />
+          <Modal.Header>
+            <ElementTitle noMarignBottom>Confirm Deposit</ElementTitle>
+          </Modal.Header>
+          <div className="bg-th-bkg-1 p-4 rounded-lg text-th-fgd-1 text-center">
+            <div className="text-th-fgd-3 pb-1">{`You're about to deposit`}</div>
+            <div className="flex items-center justify-center">
+              <div className="font-semibold relative text-xl">
+                {inputAmount}
+                <span className="absolute bottom-0.5 font-normal ml-1.5 text-xs text-th-fgd-4">
+                  {symbol}
+                </span>
+              </div>
+            </div>
+          </div>
+          {simulation ? (
+            <Disclosure>
+              {({ open }) => (
+                <>
+                  <Disclosure.Button
+                    className={`border border-th-fgd-4 default-transition font-normal mt-4 pl-3 pr-2 py-2.5 ${
+                      open ? 'rounded-b-none' : 'rounded-md'
+                    } text-th-fgd-1 w-full hover:bg-th-bkg-3 focus:outline-none`}
+                  >
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center">
+                        <span className="flex h-2 w-2 mr-2.5 relative">
+                          <span
+                            className={`animate-ping absolute inline-flex h-full w-full rounded-full ${renderAccountRiskStatus(
+                              simulation?.collateralRatio,
+                              false,
+                              true
+                            )} opacity-75`}
+                          ></span>
+                          <span
+                            className={`relative inline-flex rounded-full h-2 w-2 ${renderAccountRiskStatus(
+                              simulation?.collateralRatio,
+                              false,
+                              true
+                            )}`}
+                          ></span>
+                        </span>
+                        Account Health Check
+                        <Tooltip content="The details of your account after this deposit.">
+                          <InformationCircleIcon
+                            className={`h-5 w-5 ml-2 text-th-fgd-3 cursor-help`}
+                          />
+                        </Tooltip>
+                      </div>
+                      {open ? (
+                        <ChevronUpIcon className="h-5 w-5 mr-1" />
+                      ) : (
+                        <ChevronDownIcon className="h-5 w-5 mr-1" />
+                      )}
+                    </div>
+                  </Disclosure.Button>
+                  <Disclosure.Panel
+                    className={`border border-th-fgd-4 border-t-0 p-4 rounded-b-md`}
+                  >
+                    <div>
+                      <div className="flex justify-between pb-2">
+                        <div className="text-th-fgd-4">Account Value</div>
+                        <div className="text-th-fgd-1">
+                          ${simulation?.assetsVal.toFixed(2)}
+                        </div>
+                      </div>
+                      <div className="flex justify-between pb-2">
+                        <div className="text-th-fgd-4">Account Risk</div>
+                        <div className="text-th-fgd-1">
+                          {renderAccountRiskStatus(
+                            simulation?.collateralRatio,
+                            true
+                          )}
+                        </div>
+                      </div>
+                      <div className="flex justify-between pb-2">
+                        <div className="text-th-fgd-4">Leverage</div>
+                        <div className="text-th-fgd-1">
+                          {simulation?.leverage.toFixed(2)}x
+                        </div>
+                      </div>
+                      <div className="flex justify-between">
+                        <div className="text-th-fgd-4">Collateral Ratio</div>
+                        <div className="text-th-fgd-1">
+                          {simulation?.collateralRatio * 100 < 200
+                            ? Math.floor(simulation?.collateralRatio * 100)
+                            : '>200'}
+                          %
+                        </div>
+                      </div>
+                      {simulation?.liabsVal > 0.05 ? (
+                        <div className="flex justify-between pt-2">
+                          <div className="text-th-fgd-4">Borrow Value</div>
+                          <div className="text-th-fgd-1">
+                            ${simulation?.liabsVal.toFixed(2)}
+                          </div>
+                        </div>
+                      ) : null}
+                    </div>
+                  </Disclosure.Panel>
+                </>
+              )}
+            </Disclosure>
+          ) : null}
+          <div className={`mt-5 flex justify-center`}>
+            <Button onClick={handleDeposit} className="w-full">
+              <div className={`flex items-center justify-center`}>
+                {submitting && <Loading className="-ml-1 mr-3" />}
+                Confirm
+              </div>
+            </Button>
+          </div>
+          <LinkButton
+            className="flex items-center mt-4 text-th-fgd-3"
+            onClick={() => setShowSimulation(false)}
+          >
+            <ChevronLeftIcon className="h-5 w-5 mr-1" />
+            Back
+          </LinkButton>
         </>
       )}
     </Modal>

--- a/components/MarketHeader.tsx
+++ b/components/MarketHeader.tsx
@@ -23,14 +23,14 @@ const MarketHeader = () => {
     // calculate from and to date (0:00UTC to 23:59:59UTC)
     const date = new Date()
     const utcDate = date.getUTCDate()
-    let utcFrom = new Date(
+    const utcFrom = new Date(
       Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())
     )
     utcFrom.setUTCDate(utcDate)
     utcFrom.setUTCHours(0)
     utcFrom.setUTCMinutes(0)
     utcFrom.setUTCSeconds(0)
-    let utcTo = new Date(
+    const utcTo = new Date(
       Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())
     )
     utcTo.setUTCDate(utcDate)
@@ -113,7 +113,7 @@ const MarketHeader = () => {
             <div className="mb-0.5 text-th-fgd-4 text-xs">24hr Vol</div>
             <div className={`font-semibold`}>
               {ohlcv && !loading ? (
-                volume !== '--' ? (
+                volume && volume !== '--' ? (
                   <>
                     {volume.toFixed(2)}
                     <span className="ml-1 text-th-fgd-3 text-xs">

--- a/components/MarketHeader.tsx
+++ b/components/MarketHeader.tsx
@@ -23,20 +23,23 @@ const MarketHeader = () => {
     // calculate from and to date (0:00UTC to 23:59:59UTC)
     const date = new Date()
     const utcDate = date.getUTCDate()
+
     const utcFrom = new Date(
-      Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())
+      Date.UTC(date.getFullYear(), date.getUTCMonth(), date.getDate())
     )
     utcFrom.setUTCDate(utcDate)
     utcFrom.setUTCHours(0)
     utcFrom.setUTCMinutes(0)
     utcFrom.setUTCSeconds(0)
+
     const utcTo = new Date(
-      Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())
+      Date.UTC(date.getFullYear(), date.getUTCMonth(), date.getDate())
     )
     utcTo.setUTCDate(utcDate)
     utcTo.setUTCHours(23)
     utcTo.setUTCMinutes(59)
     utcTo.setUTCSeconds(59)
+
     const from = utcFrom.getTime() / 1000
     const to = utcTo.getTime() / 1000
 

--- a/components/MarketHeader.tsx
+++ b/components/MarketHeader.tsx
@@ -22,23 +22,26 @@ const MarketHeader = () => {
   const fetchOhlcv = useCallback(async () => {
     // calculate from and to date (0:00UTC to 23:59:59UTC)
     const date = new Date()
-    const utcDate = date.getUTCDate()
-
     const utcFrom = new Date(
-      Date.UTC(date.getFullYear(), date.getUTCMonth(), date.getDate())
+      Date.UTC(
+        date.getFullYear(),
+        date.getUTCMonth(),
+        date.getUTCDate(),
+        0,
+        0,
+        0
+      )
     )
-    utcFrom.setUTCDate(utcDate)
-    utcFrom.setUTCHours(0)
-    utcFrom.setUTCMinutes(0)
-    utcFrom.setUTCSeconds(0)
-
     const utcTo = new Date(
-      Date.UTC(date.getFullYear(), date.getUTCMonth(), date.getDate())
+      Date.UTC(
+        date.getFullYear(),
+        date.getUTCMonth(),
+        date.getUTCDate(),
+        23,
+        59,
+        59
+      )
     )
-    utcTo.setUTCDate(utcDate)
-    utcTo.setUTCHours(23)
-    utcTo.setUTCMinutes(59)
-    utcTo.setUTCSeconds(59)
 
     const from = utcFrom.getTime() / 1000
     const to = utcTo.getTime() / 1000

--- a/components/RecentMarketTrades.tsx
+++ b/components/RecentMarketTrades.tsx
@@ -14,6 +14,7 @@ export default function PublicTrades() {
 
   const fetchTradesForChart = useCallback(async () => {
     const newTrades = await ChartApi.getRecentTrades(marketAddress)
+    if (!newTrades) return null
     if (newTrades.length && trades.length === 0) {
       setTrades(newTrades)
     } else if (

--- a/components/RecentMarketTrades.tsx
+++ b/components/RecentMarketTrades.tsx
@@ -13,8 +13,8 @@ export default function PublicTrades() {
   const [trades, setTrades] = useState([])
 
   const fetchTradesForChart = useCallback(async () => {
+    if (!marketAddress) return null
     const newTrades = await ChartApi.getRecentTrades(marketAddress)
-    if (!newTrades) return null
     if (newTrades.length && trades.length === 0) {
       setTrades(newTrades)
     } else if (

--- a/components/Select.tsx
+++ b/components/Select.tsx
@@ -38,7 +38,7 @@ const Select = ({
             {open ? (
               <Listbox.Options
                 static
-                className={`text-th-fgd-1 max-h-40 overflow-auto z-20 w-full p-1 absolute left-0 mt-1 bg-th-bkg-1 origin-top-left divide-y divide-th-bkg-3 shadow-lg outline-none rounded-md thin-scroll`}
+                className={`text-th-fgd-1 max-h-60 overflow-auto z-20 w-full p-1 absolute left-0 mt-1 bg-th-bkg-1 origin-top-left divide-y divide-th-bkg-3 shadow-lg outline-none rounded-md thin-scroll`}
               >
                 {children}
               </Listbox.Options>

--- a/components/TradeForm.tsx
+++ b/components/TradeForm.tsx
@@ -9,7 +9,7 @@ import { notify } from '../utils/notifications'
 import { placeAndSettle } from '../utils/mango'
 import { calculateMarketPrice, getDecimalCount } from '../utils'
 import FloatingElement from './FloatingElement'
-import { roundToDecimal } from '../utils/index'
+import { floorToDecimal } from '../utils/index'
 import useMangoStore from '../stores/useMangoStore'
 import Button from './Button'
 import TradeType from './TradeType'
@@ -105,7 +105,7 @@ export default function TradeForm() {
       return
     }
     const rawQuoteSize = baseSize * usePrice
-    const quoteSize = baseSize && roundToDecimal(rawQuoteSize, sizeDecimalCount)
+    const quoteSize = baseSize && floorToDecimal(rawQuoteSize, sizeDecimalCount)
     setQuoteSize(quoteSize)
   }
 
@@ -122,7 +122,7 @@ export default function TradeForm() {
     }
     const usePrice = Number(price) || markPrice
     const rawBaseSize = quoteSize / usePrice
-    const baseSize = quoteSize && roundToDecimal(rawBaseSize, sizeDecimalCount)
+    const baseSize = quoteSize && floorToDecimal(rawBaseSize, sizeDecimalCount)
     setBaseSize(baseSize)
   }
 
@@ -315,7 +315,7 @@ export default function TradeForm() {
                   'border-th-green hover:border-th-green-dark'
                 } text-th-green hover:text-th-fgd-1 hover:bg-th-green-dark flex-grow`}
               >
-                {`Buy ${baseSize > 0 ? baseSize : ''} ${baseCurrency}`}
+                {`${baseSize > 0 ? 'Buy ' + baseSize : 'Enter BUY >= ' + market?.minOrderSize} ${baseCurrency}`}
               </Button>
             ) : (
               <Button
@@ -326,7 +326,7 @@ export default function TradeForm() {
                   'border-th-red hover:border-th-red-dark'
                 } text-th-red hover:text-th-fgd-1 hover:bg-th-red-dark flex-grow`}
               >
-                {`Sell ${baseSize > 0 ? baseSize : ''} ${baseCurrency}`}
+                {`${baseSize > 0 ? 'Sell ' + baseSize : 'Enter SELL bid >= ' + market?.minOrderSize} ${baseCurrency}`}
               </Button>
             )
           ) : (

--- a/components/TradeForm.tsx
+++ b/components/TradeForm.tsx
@@ -52,17 +52,29 @@ export default function TradeForm() {
 
   const setBaseSize = (baseSize) =>
     set((s) => {
-      s.tradeForm.baseSize = parseFloat(baseSize)
+      if (!Number.isNaN(parseFloat(baseSize))) {
+        s.tradeForm.baseSize = parseFloat(baseSize)
+      } else {
+        s.tradeForm.baseSize = baseSize
+      }
     })
 
   const setQuoteSize = (quoteSize) =>
     set((s) => {
-      s.tradeForm.quoteSize = parseFloat(quoteSize)
+      if (!Number.isNaN(parseFloat(quoteSize))) {
+        s.tradeForm.quoteSize = parseFloat(quoteSize)
+      } else {
+        s.tradeForm.quoteSize = quoteSize
+      }
     })
 
   const setPrice = (price) =>
     set((s) => {
-      s.tradeForm.price = parseFloat(price)
+      if (!Number.isNaN(parseFloat(price))) {
+        s.tradeForm.price = parseFloat(price)
+      } else {
+        s.tradeForm.price = price
+      }
     })
 
   const setTradeType = (type) =>
@@ -253,8 +265,9 @@ export default function TradeForm() {
         <Input.Group className="mt-4">
           <Input
             type="number"
+            min="0"
             step={market?.tickSize || 1}
-            onChange={(e) => onSetPrice(parseFloat(e.target.value))}
+            onChange={(e) => onSetPrice(e.target.value)}
             value={price}
             disabled={tradeType === 'Market'}
             prefix={'Price'}
@@ -272,8 +285,9 @@ export default function TradeForm() {
         <Input.Group className="mt-4">
           <Input
             type="number"
+            min="0"
             step={market?.minOrderSize || 1}
-            onChange={(e) => onSetBaseSize(parseFloat(e.target.value))}
+            onChange={(e) => onSetBaseSize(e.target.value)}
             value={baseSize}
             className="rounded-r-none"
             wrapperClassName="w-3/5"
@@ -282,8 +296,9 @@ export default function TradeForm() {
           />
           <StyledRightInput
             type="number"
+            min="0"
             step={market?.minOrderSize || 1}
-            onChange={(e) => onSetQuoteSize(parseFloat(e.target.value))}
+            onChange={(e) => onSetQuoteSize(e.target.value)}
             value={quoteSize}
             className="rounded-l-none"
             wrapperClassName="w-2/5"

--- a/components/WithdrawModal.tsx
+++ b/components/WithdrawModal.tsx
@@ -321,251 +321,239 @@ const WithdrawModal = ({ isOpen, onClose }) => {
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
-      {simulation ? (
+      {!showSimulation ? (
         <>
-          {!showSimulation ? (
-            <>
-              <Modal.Header>
-                <ElementTitle noMarignBottom>Withdraw Funds</ElementTitle>
-              </Modal.Header>
-              <AccountSelect
-                hideAddress
-                accounts={withdrawAccounts}
-                selectedAccount={selectedAccount}
-                onSelectAccount={handleSetSelectedAccount}
-                getBalance={getMaxForSelectedAccount}
-                symbols={symbols}
-              />
-              <div className="flex items-center jusitfy-between text-th-fgd-1 mt-4 p-2 rounded-md bg-th-bkg-3">
-                <div className="flex items-center text-fgd-1 pr-4">
-                  <span>Borrow Funds</span>
-                  <Tooltip content="Interest is charged on your borrowed balance and is subject to change.">
-                    <InformationCircleIcon
-                      className={`h-5 w-5 ml-2 text-th-fgd-3 cursor-help`}
-                    />
-                  </Tooltip>
-                </div>
-                <Switch
-                  checked={includeBorrow}
-                  className="ml-auto"
-                  onChange={(checked) => handleIncludeBorrowSwitch(checked)}
+          <Modal.Header>
+            <ElementTitle noMarignBottom>Withdraw Funds</ElementTitle>
+          </Modal.Header>
+          <AccountSelect
+            hideAddress
+            accounts={withdrawAccounts}
+            selectedAccount={selectedAccount}
+            onSelectAccount={handleSetSelectedAccount}
+            getBalance={getMaxForSelectedAccount}
+            symbols={symbols}
+          />
+          <div className="flex items-center jusitfy-between text-th-fgd-1 mt-4 p-2 rounded-md bg-th-bkg-3">
+            <div className="flex items-center text-fgd-1 pr-4">
+              <span>Borrow Funds</span>
+              <Tooltip content="Interest is charged on your borrowed balance and is subject to change.">
+                <InformationCircleIcon
+                  className={`h-5 w-5 ml-2 text-th-fgd-3 cursor-help`}
                 />
-              </div>
-              <div className="flex justify-between pb-2 pt-4">
-                <div className="text-th-fgd-1">Amount</div>
-                <div className="flex space-x-4">
-                  <div
-                    className="text-th-fgd-1 underline cursor-pointer default-transition hover:text-th-primary hover:no-underline"
-                    onClick={
-                      includeBorrow
-                        ? setMaxBorrowForSelectedAccount
-                        : setMaxForSelectedAccount
-                    }
-                  >
-                    Max
-                  </div>
-                </div>
-              </div>
-              <div className="flex">
-                <Input
-                  type="number"
-                  min="0"
-                  className={`border border-th-fgd-4 flex-grow pr-11`}
-                  error={!!invalidAmountMessage}
-                  placeholder="0.00"
-                  value={inputAmount}
-                  onBlur={validateAmountInput}
-                  onChange={(e) => onChangeAmountInput(e.target.value)}
-                  suffix={symbol}
-                />
-                <Tooltip content="Account Leverage" className="py-1">
-                  <span
-                    className={`${renderAccountRiskStatus(
-                      simulation.collateralRatio
-                    )} bg-th-bkg-1 border flex font-semibold h-10 items-center justify-center ml-2 rounded text-th-fgd-1 w-14`}
-                  >
-                    {simulation.leverage < 5
-                      ? simulation.leverage.toFixed(2)
-                      : '>5'}
-                    x
-                  </span>
-                </Tooltip>
-              </div>
-              {invalidAmountMessage ? (
-                <div className="flex items-center pt-1.5 text-th-red">
-                  <ExclamationCircleIcon className="h-4 w-4 mr-1.5" />
-                  {invalidAmountMessage}
-                </div>
-              ) : null}
-              <div className="pt-3 pb-4">
-                <Slider
-                  disabled={null}
-                  value={sliderPercentage}
-                  onChange={(v) => onChangeSlider(v)}
-                  step={1}
-                  maxButtonTransition={maxButtonTransition}
-                />
-              </div>
-              <div className={`mt-5 flex justify-center`}>
-                <Button
-                  onClick={() => setShowSimulation(true)}
-                  disabled={
-                    Number(inputAmount) <= 0 || simulation.collateralRatio < 1.2
-                  }
-                  className="w-full"
-                >
-                  Next
-                </Button>
-              </div>
-            </>
-          ) : (
-            <>
-              <Modal.Header>
-                <ElementTitle noMarignBottom>Confirm Withdraw</ElementTitle>
-              </Modal.Header>
-              {simulation.collateralRatio < 1.2 ? (
-                <div className="border border-th-red mb-4 p-2 rounded">
-                  <div className="flex items-center text-th-red">
-                    <ExclamationCircleIcon className="h-4 w-4 mr-1.5 flex-shrink-0" />
-                    Prices have changed and increased your leverage. Reduce the
-                    withdrawal amount.
-                  </div>
-                </div>
-              ) : null}
-              <div className="bg-th-bkg-1 p-4 rounded-lg text-th-fgd-1 text-center">
-                <div className="text-th-fgd-3 pb-1">{`You're about to withdraw`}</div>
-                <div className="flex items-center justify-center">
-                  <div className="font-semibold relative text-xl">
-                    {inputAmount}
-                    <span className="absolute bottom-0.5 font-normal ml-1.5 text-xs text-th-fgd-4">
-                      {symbol}
-                    </span>
-                  </div>
-                </div>
-                {getBorrowAmount() > 0 ? (
-                  <div className="pt-2 text-th-fgd-4">{`Includes borrow of ~${getBorrowAmount().toFixed(
-                    DECIMALS[symbol]
-                  )} ${symbol}`}</div>
-                ) : null}
-              </div>
-              <Disclosure>
-                {({ open }) => (
-                  <>
-                    <Disclosure.Button
-                      className={`border border-th-fgd-4 default-transition font-normal mt-4 pl-3 pr-2 py-2.5 ${
-                        open ? 'rounded-b-none' : 'rounded-md'
-                      } text-th-fgd-1 w-full hover:bg-th-bkg-3 focus:outline-none`}
-                    >
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center">
-                          <span className="flex h-2 w-2 mr-2.5 relative">
-                            <span
-                              className={`animate-ping absolute inline-flex h-full w-full rounded-full ${renderAccountRiskStatus(
-                                simulation.collateralRatio,
-                                false,
-                                true
-                              )} opacity-75`}
-                            ></span>
-                            <span
-                              className={`relative inline-flex rounded-full h-2 w-2 ${renderAccountRiskStatus(
-                                simulation.collateralRatio,
-                                false,
-                                true
-                              )}`}
-                            ></span>
-                          </span>
-                          Account Health Check
-                          <Tooltip content="The details of your account after this withdrawal.">
-                            <InformationCircleIcon
-                              className={`h-5 w-5 ml-2 text-th-fgd-3 cursor-help`}
-                            />
-                          </Tooltip>
-                        </div>
-                        {open ? (
-                          <ChevronUpIcon className="h-5 w-5 mr-1" />
-                        ) : (
-                          <ChevronDownIcon className="h-5 w-5 mr-1" />
-                        )}
-                      </div>
-                    </Disclosure.Button>
-                    <Disclosure.Panel
-                      className={`border border-th-fgd-4 border-t-0 p-4 rounded-b-md`}
-                    >
-                      <div>
-                        <div className="flex justify-between pb-2">
-                          <div className="text-th-fgd-4">Account Value</div>
-                          <div className="text-th-fgd-1">
-                            ${simulation.assetsVal.toFixed(2)}
-                          </div>
-                        </div>
-                        <div className="flex justify-between pb-2">
-                          <div className="text-th-fgd-4">Account Risk</div>
-                          <div className="text-th-fgd-1">
-                            {renderAccountRiskStatus(
-                              simulation.collateralRatio,
-                              true
-                            )}
-                          </div>
-                        </div>
-                        <div className="flex justify-between pb-2">
-                          <div className="text-th-fgd-4">Leverage</div>
-                          <div className="text-th-fgd-1">
-                            {simulation.leverage.toFixed(2)}x
-                          </div>
-                        </div>
-                        <div className="flex justify-between">
-                          <div className="text-th-fgd-4">Collateral Ratio</div>
-                          <div className="text-th-fgd-1">
-                            {simulation.collateralRatio * 100 < 200
-                              ? Math.floor(simulation.collateralRatio * 100)
-                              : '>200'}
-                            %
-                          </div>
-                        </div>
-                        {simulation.liabsVal > 0.05 ? (
-                          <div className="flex justify-between pt-2">
-                            <div className="text-th-fgd-4">Borrow Value</div>
-                            <div className="text-th-fgd-1">
-                              ${simulation.liabsVal.toFixed(2)}
-                            </div>
-                          </div>
-                        ) : null}
-                      </div>
-                    </Disclosure.Panel>
-                  </>
-                )}
-              </Disclosure>
-              <div className={`mt-5 flex justify-center`}>
-                <Button
-                  onClick={handleWithdraw}
-                  disabled={
-                    Number(inputAmount) <= 0 || simulation.collateralRatio < 1.2
-                  }
-                  className="w-full"
-                >
-                  <div className={`flex items-center justify-center`}>
-                    {submitting && <Loading className="-ml-1 mr-3" />}
-                    Confirm
-                  </div>
-                </Button>
-              </div>
-              <LinkButton
-                className="flex items-center mt-4 text-th-fgd-3"
-                onClick={() => setShowSimulation(false)}
+              </Tooltip>
+            </div>
+            <Switch
+              checked={includeBorrow}
+              className="ml-auto"
+              onChange={(checked) => handleIncludeBorrowSwitch(checked)}
+            />
+          </div>
+          <div className="flex justify-between pb-2 pt-4">
+            <div className="text-th-fgd-1">Amount</div>
+            <div className="flex space-x-4">
+              <div
+                className="text-th-fgd-1 underline cursor-pointer default-transition hover:text-th-primary hover:no-underline"
+                onClick={
+                  includeBorrow
+                    ? setMaxBorrowForSelectedAccount
+                    : setMaxForSelectedAccount
+                }
               >
-                <ChevronLeftIcon className="h-5 w-5 mr-1" />
-                Back
-              </LinkButton>
-            </>
-          )}
+                Max
+              </div>
+            </div>
+          </div>
+          <div className="flex">
+            <Input
+              type="number"
+              min="0"
+              className={`border border-th-fgd-4 flex-grow pr-11`}
+              error={!!invalidAmountMessage}
+              placeholder="0.00"
+              value={inputAmount}
+              onBlur={validateAmountInput}
+              onChange={(e) => onChangeAmountInput(e.target.value)}
+              suffix={symbol}
+            />
+            <Tooltip content="Account Leverage" className="py-1">
+              <span
+                className={`${renderAccountRiskStatus(
+                  simulation?.collateralRatio
+                )} bg-th-bkg-1 border flex font-semibold h-10 items-center justify-center ml-2 rounded text-th-fgd-1 w-14`}
+              >
+                {simulation?.leverage < 5
+                  ? simulation?.leverage.toFixed(2)
+                  : '>5'}
+                x
+              </span>
+            </Tooltip>
+          </div>
+          {invalidAmountMessage ? (
+            <div className="flex items-center pt-1.5 text-th-red">
+              <ExclamationCircleIcon className="h-4 w-4 mr-1.5" />
+              {invalidAmountMessage}
+            </div>
+          ) : null}
+          <div className="pt-3 pb-4">
+            <Slider
+              disabled={null}
+              value={sliderPercentage}
+              onChange={(v) => onChangeSlider(v)}
+              step={1}
+              maxButtonTransition={maxButtonTransition}
+            />
+          </div>
+          <div className={`mt-5 flex justify-center`}>
+            <Button
+              onClick={() => setShowSimulation(true)}
+              disabled={
+                Number(inputAmount) <= 0 || simulation?.collateralRatio < 1.2
+              }
+              className="w-full"
+            >
+              Next
+            </Button>
+          </div>
         </>
       ) : (
         <>
-          <div className="animate-pulse bg-th-bkg-3 h-10 mb-4 rounded w-full" />
-          <div className="animate-pulse bg-th-bkg-3 h-10 mb-4 rounded w-full" />
-          <div className="animate-pulse bg-th-bkg-3 h-10 mb-4 rounded w-full" />
-          <div className="animate-pulse bg-th-bkg-3 h-10 mb-4 rounded w-full" />
-          <div className="animate-pulse bg-th-bkg-3 h-10 mb-4 rounded w-full" />
+          <Modal.Header>
+            <ElementTitle noMarignBottom>Confirm Withdraw</ElementTitle>
+          </Modal.Header>
+          {simulation?.collateralRatio < 1.2 ? (
+            <div className="border border-th-red mb-4 p-2 rounded">
+              <div className="flex items-center text-th-red">
+                <ExclamationCircleIcon className="h-4 w-4 mr-1.5 flex-shrink-0" />
+                Prices have changed and increased your leverage. Reduce the
+                withdrawal amount.
+              </div>
+            </div>
+          ) : null}
+          <div className="bg-th-bkg-1 p-4 rounded-lg text-th-fgd-1 text-center">
+            <div className="text-th-fgd-3 pb-1">{`You're about to withdraw`}</div>
+            <div className="flex items-center justify-center">
+              <div className="font-semibold relative text-xl">
+                {inputAmount}
+                <span className="absolute bottom-0.5 font-normal ml-1.5 text-xs text-th-fgd-4">
+                  {symbol}
+                </span>
+              </div>
+            </div>
+            {getBorrowAmount() > 0 ? (
+              <div className="pt-2 text-th-fgd-4">{`Includes borrow of ~${getBorrowAmount().toFixed(
+                DECIMALS[symbol]
+              )} ${symbol}`}</div>
+            ) : null}
+          </div>
+          <Disclosure>
+            {({ open }) => (
+              <>
+                <Disclosure.Button
+                  className={`border border-th-fgd-4 default-transition font-normal mt-4 pl-3 pr-2 py-2.5 ${
+                    open ? 'rounded-b-none' : 'rounded-md'
+                  } text-th-fgd-1 w-full hover:bg-th-bkg-3 focus:outline-none`}
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center">
+                      <span className="flex h-2 w-2 mr-2.5 relative">
+                        <span
+                          className={`animate-ping absolute inline-flex h-full w-full rounded-full ${renderAccountRiskStatus(
+                            simulation?.collateralRatio,
+                            false,
+                            true
+                          )} opacity-75`}
+                        ></span>
+                        <span
+                          className={`relative inline-flex rounded-full h-2 w-2 ${renderAccountRiskStatus(
+                            simulation?.collateralRatio,
+                            false,
+                            true
+                          )}`}
+                        ></span>
+                      </span>
+                      Account Health Check
+                      <Tooltip content="The details of your account after this withdrawal.">
+                        <InformationCircleIcon
+                          className={`h-5 w-5 ml-2 text-th-fgd-3 cursor-help`}
+                        />
+                      </Tooltip>
+                    </div>
+                    {open ? (
+                      <ChevronUpIcon className="h-5 w-5 mr-1" />
+                    ) : (
+                      <ChevronDownIcon className="h-5 w-5 mr-1" />
+                    )}
+                  </div>
+                </Disclosure.Button>
+                <Disclosure.Panel
+                  className={`border border-th-fgd-4 border-t-0 p-4 rounded-b-md`}
+                >
+                  <div>
+                    <div className="flex justify-between pb-2">
+                      <div className="text-th-fgd-4">Account Value</div>
+                      <div className="text-th-fgd-1">
+                        ${simulation?.assetsVal.toFixed(2)}
+                      </div>
+                    </div>
+                    <div className="flex justify-between pb-2">
+                      <div className="text-th-fgd-4">Account Risk</div>
+                      <div className="text-th-fgd-1">
+                        {renderAccountRiskStatus(
+                          simulation?.collateralRatio,
+                          true
+                        )}
+                      </div>
+                    </div>
+                    <div className="flex justify-between pb-2">
+                      <div className="text-th-fgd-4">Leverage</div>
+                      <div className="text-th-fgd-1">
+                        {simulation?.leverage.toFixed(2)}x
+                      </div>
+                    </div>
+                    <div className="flex justify-between">
+                      <div className="text-th-fgd-4">Collateral Ratio</div>
+                      <div className="text-th-fgd-1">
+                        {simulation?.collateralRatio * 100 < 200
+                          ? Math.floor(simulation?.collateralRatio * 100)
+                          : '>200'}
+                        %
+                      </div>
+                    </div>
+                    {simulation?.liabsVal > 0.05 ? (
+                      <div className="flex justify-between pt-2">
+                        <div className="text-th-fgd-4">Borrow Value</div>
+                        <div className="text-th-fgd-1">
+                          ${simulation?.liabsVal.toFixed(2)}
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
+                </Disclosure.Panel>
+              </>
+            )}
+          </Disclosure>
+          <div className={`mt-5 flex justify-center`}>
+            <Button
+              onClick={handleWithdraw}
+              disabled={
+                Number(inputAmount) <= 0 || simulation?.collateralRatio < 1.2
+              }
+              className="w-full"
+            >
+              <div className={`flex items-center justify-center`}>
+                {submitting && <Loading className="-ml-1 mr-3" />}
+                Confirm
+              </div>
+            </Button>
+          </div>
+          <LinkButton
+            className="flex items-center mt-4 text-th-fgd-3"
+            onClick={() => setShowSimulation(false)}
+          >
+            <ChevronLeftIcon className="h-5 w-5 mr-1" />
+            Back
+          </LinkButton>
         </>
       )}
     </Modal>

--- a/components/WithdrawModal.tsx
+++ b/components/WithdrawModal.tsx
@@ -8,6 +8,8 @@ import useMarketList from '../hooks/useMarketList'
 import {
   getSymbolForTokenMintAddress,
   displayDepositsForMarginAccount,
+  DECIMALS,
+  trimDecimals,
 } from '../utils/index'
 import useConnection from '../hooks/useConnection'
 import { borrowAndWithdraw, withdraw } from '../utils/mango'
@@ -26,7 +28,7 @@ import {
   ChevronDownIcon,
   ChevronUpIcon,
 } from '@heroicons/react/solid'
-import { Disclosure, Transition } from '@headlessui/react'
+import { Disclosure } from '@headlessui/react'
 import { PublicKey } from '@solana/web3.js'
 import { MarginAccount, uiToNative } from '@blockworks-foundation/mango-client'
 
@@ -57,21 +59,17 @@ const WithdrawModal = ({ isOpen, onClose }) => {
     [symbols, walletAccounts]
   )
   const [selectedAccount, setSelectedAccount] = useState(withdrawAccounts[0])
-  const mintAddress = useMemo(() => selectedAccount?.account.mint.toString(), [
-    selectedAccount,
-  ])
-  const tokenIndex = useMemo(() => getTokenIndex(mintAddress), [
-    mintAddress,
-    getTokenIndex,
-  ])
+  const mintAddress = useMemo(
+    () => selectedAccount?.account.mint.toString(),
+    [selectedAccount]
+  )
+  const tokenIndex = useMemo(
+    () => getTokenIndex(mintAddress),
+    [mintAddress, getTokenIndex]
+  )
   const symbol = getSymbolForTokenMintAddress(
     selectedAccount?.account?.mint.toString()
   )
-  const DECIMALS = {
-    BTC: 6,
-    ETH: 5,
-    USDT: 2,
-  }
 
   useEffect(() => {
     if (!selectedMangoGroup || !selectedMarginAccount) return
@@ -216,6 +214,7 @@ const WithdrawModal = ({ isOpen, onClose }) => {
   const handleSetSelectedAccount = (val) => {
     setInputAmount(0)
     setSliderPercentage(0)
+    setInvalidAmountMessage('')
     setSelectedAccount(val)
   }
 
@@ -233,31 +232,31 @@ const WithdrawModal = ({ isOpen, onClose }) => {
     return borrowAmount > 0 ? borrowAmount : 0
   }
 
-  const getAccountStatusColor = (
+  const renderAccountRiskStatus = (
     collateralRatio: number,
-    isRisk?: boolean,
-    isStatus?: boolean
+    isRiskLevel?: boolean,
+    isStatusIcon?: boolean
   ) => {
     if (collateralRatio < 1.25) {
-      return isRisk ? (
+      return isRiskLevel ? (
         <div className="text-th-red">High</div>
-      ) : isStatus ? (
+      ) : isStatusIcon ? (
         'bg-th-red'
       ) : (
         'border-th-red text-th-red'
       )
     } else if (collateralRatio > 1.25 && collateralRatio < 1.5) {
-      return isRisk ? (
+      return isRiskLevel ? (
         <div className="text-th-orange">Moderate</div>
-      ) : isStatus ? (
+      ) : isStatusIcon ? (
         'bg-th-orange'
       ) : (
         'border-th-orange text-th-orange'
       )
     } else {
-      return isRisk ? (
+      return isRiskLevel ? (
         <div className="text-th-green">Low</div>
-      ) : isStatus ? (
+      ) : isStatusIcon ? (
         'bg-th-green'
       ) : (
         'border-th-green text-th-green'
@@ -302,20 +301,13 @@ const WithdrawModal = ({ isOpen, onClose }) => {
   const validateAmountInput = (e) => {
     const amount = e.target.value
     if (Number(amount) <= 0) {
-      setInvalidAmountMessage('Withdrawal amount must be greater than 0')
+      setInvalidAmountMessage('Enter an amount to withdraw')
     }
     if (simulation.collateralRatio < 1.2) {
       setInvalidAmountMessage(
         'Leverage too high. Reduce the amount to withdraw'
       )
     }
-  }
-
-  const trimDecimals = (n, digits) => {
-    var step = Math.pow(10, digits || 0)
-    var temp = Math.trunc(step * n)
-
-    return temp / step
   }
 
   // turn off slider transition for dragging slider handle interaction
@@ -331,261 +323,241 @@ const WithdrawModal = ({ isOpen, onClose }) => {
     <Modal isOpen={isOpen} onClose={onClose}>
       {simulation ? (
         <>
-          <Transition
-            appear={true}
-            show={!showSimulation}
-            enter="transition ease-out delay-200 duration-500"
-            enterFrom="opacity-0"
-            enterTo="opacity-100"
-          >
-            {!showSimulation ? (
-              <>
-                <Modal.Header>
-                  <ElementTitle noMarignBottom>Withdraw Funds</ElementTitle>
-                </Modal.Header>
-                <AccountSelect
-                  hideAddress
-                  accounts={withdrawAccounts}
-                  selectedAccount={selectedAccount}
-                  onSelectAccount={handleSetSelectedAccount}
-                  getBalance={getMaxForSelectedAccount}
-                  symbols={symbols}
-                />
-                <div className="flex items-center jusitfy-between text-th-fgd-1 mt-4 p-2 rounded-md bg-th-bkg-3">
-                  <div className="flex items-center text-fgd-1 pr-4">
-                    <span>Borrow Funds</span>
-                    <Tooltip content="Interest is charged on your borrowed balance and is subject to change.">
-                      <InformationCircleIcon
-                        className={`h-5 w-5 ml-2 text-th-fgd-3 cursor-help`}
-                      />
-                    </Tooltip>
-                  </div>
-                  <Switch
-                    checked={includeBorrow}
-                    className="ml-auto"
-                    onChange={(checked) => handleIncludeBorrowSwitch(checked)}
-                  />
-                </div>
-                <div className="flex justify-between pb-2 pt-4">
-                  <div className="text-th-fgd-1">Amount</div>
-                  <div className="flex space-x-4">
-                    <div
-                      className="text-th-fgd-1 underline cursor-pointer default-transition hover:text-th-primary hover:no-underline"
-                      onClick={
-                        includeBorrow
-                          ? setMaxBorrowForSelectedAccount
-                          : setMaxForSelectedAccount
-                      }
-                    >
-                      Max
-                    </div>
-                  </div>
-                </div>
-                <div className="flex">
-                  <Input
-                    type="number"
-                    min="0"
-                    className={`border border-th-fgd-4 flex-grow pr-11`}
-                    error={!!invalidAmountMessage}
-                    placeholder="0.00"
-                    value={inputAmount}
-                    onBlur={validateAmountInput}
-                    onChange={(e) => onChangeAmountInput(e.target.value)}
-                    suffix={symbol}
-                  />
-                  <Tooltip content="Account Leverage" className="py-1">
-                    <span
-                      className={`${getAccountStatusColor(
-                        simulation.collateralRatio
-                      )} bg-th-bkg-1 border flex font-semibold h-10 items-center justify-center ml-2 rounded text-th-fgd-1 w-14`}
-                    >
-                      {simulation.leverage < 5
-                        ? simulation.leverage.toFixed(2)
-                        : '>5'}
-                      x
-                    </span>
+          {!showSimulation ? (
+            <>
+              <Modal.Header>
+                <ElementTitle noMarignBottom>Withdraw Funds</ElementTitle>
+              </Modal.Header>
+              <AccountSelect
+                hideAddress
+                accounts={withdrawAccounts}
+                selectedAccount={selectedAccount}
+                onSelectAccount={handleSetSelectedAccount}
+                getBalance={getMaxForSelectedAccount}
+                symbols={symbols}
+              />
+              <div className="flex items-center jusitfy-between text-th-fgd-1 mt-4 p-2 rounded-md bg-th-bkg-3">
+                <div className="flex items-center text-fgd-1 pr-4">
+                  <span>Borrow Funds</span>
+                  <Tooltip content="Interest is charged on your borrowed balance and is subject to change.">
+                    <InformationCircleIcon
+                      className={`h-5 w-5 ml-2 text-th-fgd-3 cursor-help`}
+                    />
                   </Tooltip>
                 </div>
-                {invalidAmountMessage ? (
-                  <div className="flex items-center pt-1.5 text-th-red">
-                    <ExclamationCircleIcon className="h-4 w-4 mr-1.5" />
-                    {invalidAmountMessage}
-                  </div>
-                ) : null}
-                <div className="pt-3 pb-4">
-                  <Slider
-                    disabled={null}
-                    value={sliderPercentage}
-                    onChange={(v) => onChangeSlider(v)}
-                    step={1}
-                    maxButtonTransition={maxButtonTransition}
-                  />
-                </div>
-                <div className={`mt-5 flex justify-center`}>
-                  <Button
-                    onClick={() => setShowSimulation(true)}
-                    disabled={
-                      Number(inputAmount) <= 0 ||
-                      simulation.collateralRatio < 1.2
+                <Switch
+                  checked={includeBorrow}
+                  className="ml-auto"
+                  onChange={(checked) => handleIncludeBorrowSwitch(checked)}
+                />
+              </div>
+              <div className="flex justify-between pb-2 pt-4">
+                <div className="text-th-fgd-1">Amount</div>
+                <div className="flex space-x-4">
+                  <div
+                    className="text-th-fgd-1 underline cursor-pointer default-transition hover:text-th-primary hover:no-underline"
+                    onClick={
+                      includeBorrow
+                        ? setMaxBorrowForSelectedAccount
+                        : setMaxForSelectedAccount
                     }
-                    className="w-full"
                   >
-                    Next
-                  </Button>
-                </div>
-              </>
-            ) : null}
-          </Transition>
-          <Transition
-            show={showSimulation}
-            enter="transition ease-out delay-200 duration-500"
-            enterFrom="opacity-0"
-            enterTo="opacity-100"
-          >
-            {showSimulation ? (
-              <>
-                <Modal.Header>
-                  <ElementTitle noMarignBottom>Confirm Withdraw</ElementTitle>
-                </Modal.Header>
-                {simulation.collateralRatio < 1.2 ? (
-                  <div className="border border-th-red mb-4 p-2 rounded">
-                    <div className="flex items-center text-th-red">
-                      <ExclamationCircleIcon className="h-4 w-4 mr-1.5 flex-shrink-0" />
-                      Prices have changed and increased your leverage. Reduce
-                      the withdrawal amount.
-                    </div>
+                    Max
                   </div>
-                ) : null}
-                <div className="bg-th-bkg-1 p-4 rounded-lg text-th-fgd-1 text-center">
-                  <div className="text-th-fgd-3 pb-1">{`You're about to withdraw`}</div>
-                  <div className="flex items-center justify-center">
-                    <div className="font-semibold relative text-xl">
-                      {inputAmount}
-                      <span className="absolute bottom-0.5 font-normal ml-1.5 text-xs text-th-fgd-4">
-                        {symbol}
-                      </span>
-                    </div>
-                  </div>
-                  {getBorrowAmount() > 0 ? (
-                    <div className="pt-2 text-th-fgd-4">{`Includes borrow of ~${getBorrowAmount().toFixed(
-                      DECIMALS[symbol]
-                    )} ${symbol}`}</div>
-                  ) : null}
                 </div>
-                <Disclosure>
-                  {({ open }) => (
-                    <>
-                      <Disclosure.Button
-                        className={`border border-th-fgd-4 default-transition font-normal mt-4 pl-3 pr-2 py-2.5 ${
-                          open ? 'rounded-b-none' : 'rounded-md'
-                        } text-th-fgd-1 w-full hover:bg-th-bkg-3 focus:outline-none`}
-                      >
-                        <div className="flex items-center justify-between">
-                          <div className="flex items-center">
-                            <span className="flex h-2 w-2 mr-2.5 relative">
-                              <span
-                                className={`animate-ping absolute inline-flex h-full w-full rounded-full ${getAccountStatusColor(
-                                  simulation.collateralRatio,
-                                  false,
-                                  true
-                                )} opacity-75`}
-                              ></span>
-                              <span
-                                className={`relative inline-flex rounded-full h-2 w-2 ${getAccountStatusColor(
-                                  simulation.collateralRatio,
-                                  false,
-                                  true
-                                )}`}
-                              ></span>
-                            </span>
-                            Account Health Check
-                            <Tooltip content="The details of your account after this withdrawal.">
-                              <InformationCircleIcon
-                                className={`h-5 w-5 ml-2 text-th-fgd-3 cursor-help`}
-                              />
-                            </Tooltip>
-                          </div>
-                          {open ? (
-                            <ChevronUpIcon className="h-5 w-5 mr-1" />
-                          ) : (
-                            <ChevronDownIcon className="h-5 w-5 mr-1" />
-                          )}
-                        </div>
-                      </Disclosure.Button>
-                      <Disclosure.Panel
-                        className={`border border-th-fgd-4 border-t-0 p-4 rounded-b-md`}
-                      >
-                        <div>
-                          <div className="flex justify-between pb-2">
-                            <div className="text-th-fgd-4">Account Value</div>
-                            <div className="text-th-fgd-1">
-                              ${simulation.assetsVal.toFixed(2)}
-                            </div>
-                          </div>
-                          <div className="flex justify-between pb-2">
-                            <div className="text-th-fgd-4">Account Risk</div>
-                            <div className="text-th-fgd-1">
-                              {getAccountStatusColor(
-                                simulation.collateralRatio,
-                                true
-                              )}
-                            </div>
-                          </div>
-                          <div className="flex justify-between pb-2">
-                            <div className="text-th-fgd-4">Leverage</div>
-                            <div className="text-th-fgd-1">
-                              {simulation.leverage.toFixed(2)}x
-                            </div>
-                          </div>
-                          <div className="flex justify-between">
-                            <div className="text-th-fgd-4">
-                              Collateral Ratio
-                            </div>
-                            <div className="text-th-fgd-1">
-                              {simulation.collateralRatio * 100 < 200
-                                ? Math.floor(simulation.collateralRatio * 100)
-                                : '>200'}
-                              %
-                            </div>
-                          </div>
-                          {simulation.liabsVal > 0.05 ? (
-                            <div className="flex justify-between pt-2">
-                              <div className="text-th-fgd-4">Borrow Value</div>
-                              <div className="text-th-fgd-1">
-                                ${simulation.liabsVal.toFixed(2)}
-                              </div>
-                            </div>
-                          ) : null}
-                        </div>
-                      </Disclosure.Panel>
-                    </>
-                  )}
-                </Disclosure>
-                <div className={`mt-5 flex justify-center`}>
-                  <Button
-                    onClick={handleWithdraw}
-                    disabled={
-                      Number(inputAmount) <= 0 ||
-                      simulation.collateralRatio < 1.2
-                    }
-                    className="w-full"
+              </div>
+              <div className="flex">
+                <Input
+                  type="number"
+                  min="0"
+                  className={`border border-th-fgd-4 flex-grow pr-11`}
+                  error={!!invalidAmountMessage}
+                  placeholder="0.00"
+                  value={inputAmount}
+                  onBlur={validateAmountInput}
+                  onChange={(e) => onChangeAmountInput(e.target.value)}
+                  suffix={symbol}
+                />
+                <Tooltip content="Account Leverage" className="py-1">
+                  <span
+                    className={`${renderAccountRiskStatus(
+                      simulation.collateralRatio
+                    )} bg-th-bkg-1 border flex font-semibold h-10 items-center justify-center ml-2 rounded text-th-fgd-1 w-14`}
                   >
-                    <div className={`flex items-center justify-center`}>
-                      {submitting && <Loading className="-ml-1 mr-3" />}
-                      Confirm
-                    </div>
-                  </Button>
+                    {simulation.leverage < 5
+                      ? simulation.leverage.toFixed(2)
+                      : '>5'}
+                    x
+                  </span>
+                </Tooltip>
+              </div>
+              {invalidAmountMessage ? (
+                <div className="flex items-center pt-1.5 text-th-red">
+                  <ExclamationCircleIcon className="h-4 w-4 mr-1.5" />
+                  {invalidAmountMessage}
                 </div>
-                <LinkButton
-                  className="flex items-center mt-4 text-th-fgd-3"
-                  onClick={() => setShowSimulation(false)}
+              ) : null}
+              <div className="pt-3 pb-4">
+                <Slider
+                  disabled={null}
+                  value={sliderPercentage}
+                  onChange={(v) => onChangeSlider(v)}
+                  step={1}
+                  maxButtonTransition={maxButtonTransition}
+                />
+              </div>
+              <div className={`mt-5 flex justify-center`}>
+                <Button
+                  onClick={() => setShowSimulation(true)}
+                  disabled={
+                    Number(inputAmount) <= 0 || simulation.collateralRatio < 1.2
+                  }
+                  className="w-full"
                 >
-                  <ChevronLeftIcon className="h-5 w-5 mr-1" />
-                  Back
-                </LinkButton>
-              </>
-            ) : null}
-          </Transition>
+                  Next
+                </Button>
+              </div>
+            </>
+          ) : (
+            <>
+              <Modal.Header>
+                <ElementTitle noMarignBottom>Confirm Withdraw</ElementTitle>
+              </Modal.Header>
+              {simulation.collateralRatio < 1.2 ? (
+                <div className="border border-th-red mb-4 p-2 rounded">
+                  <div className="flex items-center text-th-red">
+                    <ExclamationCircleIcon className="h-4 w-4 mr-1.5 flex-shrink-0" />
+                    Prices have changed and increased your leverage. Reduce the
+                    withdrawal amount.
+                  </div>
+                </div>
+              ) : null}
+              <div className="bg-th-bkg-1 p-4 rounded-lg text-th-fgd-1 text-center">
+                <div className="text-th-fgd-3 pb-1">{`You're about to withdraw`}</div>
+                <div className="flex items-center justify-center">
+                  <div className="font-semibold relative text-xl">
+                    {inputAmount}
+                    <span className="absolute bottom-0.5 font-normal ml-1.5 text-xs text-th-fgd-4">
+                      {symbol}
+                    </span>
+                  </div>
+                </div>
+                {getBorrowAmount() > 0 ? (
+                  <div className="pt-2 text-th-fgd-4">{`Includes borrow of ~${getBorrowAmount().toFixed(
+                    DECIMALS[symbol]
+                  )} ${symbol}`}</div>
+                ) : null}
+              </div>
+              <Disclosure>
+                {({ open }) => (
+                  <>
+                    <Disclosure.Button
+                      className={`border border-th-fgd-4 default-transition font-normal mt-4 pl-3 pr-2 py-2.5 ${
+                        open ? 'rounded-b-none' : 'rounded-md'
+                      } text-th-fgd-1 w-full hover:bg-th-bkg-3 focus:outline-none`}
+                    >
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center">
+                          <span className="flex h-2 w-2 mr-2.5 relative">
+                            <span
+                              className={`animate-ping absolute inline-flex h-full w-full rounded-full ${renderAccountRiskStatus(
+                                simulation.collateralRatio,
+                                false,
+                                true
+                              )} opacity-75`}
+                            ></span>
+                            <span
+                              className={`relative inline-flex rounded-full h-2 w-2 ${renderAccountRiskStatus(
+                                simulation.collateralRatio,
+                                false,
+                                true
+                              )}`}
+                            ></span>
+                          </span>
+                          Account Health Check
+                          <Tooltip content="The details of your account after this withdrawal.">
+                            <InformationCircleIcon
+                              className={`h-5 w-5 ml-2 text-th-fgd-3 cursor-help`}
+                            />
+                          </Tooltip>
+                        </div>
+                        {open ? (
+                          <ChevronUpIcon className="h-5 w-5 mr-1" />
+                        ) : (
+                          <ChevronDownIcon className="h-5 w-5 mr-1" />
+                        )}
+                      </div>
+                    </Disclosure.Button>
+                    <Disclosure.Panel
+                      className={`border border-th-fgd-4 border-t-0 p-4 rounded-b-md`}
+                    >
+                      <div>
+                        <div className="flex justify-between pb-2">
+                          <div className="text-th-fgd-4">Account Value</div>
+                          <div className="text-th-fgd-1">
+                            ${simulation.assetsVal.toFixed(2)}
+                          </div>
+                        </div>
+                        <div className="flex justify-between pb-2">
+                          <div className="text-th-fgd-4">Account Risk</div>
+                          <div className="text-th-fgd-1">
+                            {renderAccountRiskStatus(
+                              simulation.collateralRatio,
+                              true
+                            )}
+                          </div>
+                        </div>
+                        <div className="flex justify-between pb-2">
+                          <div className="text-th-fgd-4">Leverage</div>
+                          <div className="text-th-fgd-1">
+                            {simulation.leverage.toFixed(2)}x
+                          </div>
+                        </div>
+                        <div className="flex justify-between">
+                          <div className="text-th-fgd-4">Collateral Ratio</div>
+                          <div className="text-th-fgd-1">
+                            {simulation.collateralRatio * 100 < 200
+                              ? Math.floor(simulation.collateralRatio * 100)
+                              : '>200'}
+                            %
+                          </div>
+                        </div>
+                        {simulation.liabsVal > 0.05 ? (
+                          <div className="flex justify-between pt-2">
+                            <div className="text-th-fgd-4">Borrow Value</div>
+                            <div className="text-th-fgd-1">
+                              ${simulation.liabsVal.toFixed(2)}
+                            </div>
+                          </div>
+                        ) : null}
+                      </div>
+                    </Disclosure.Panel>
+                  </>
+                )}
+              </Disclosure>
+              <div className={`mt-5 flex justify-center`}>
+                <Button
+                  onClick={handleWithdraw}
+                  disabled={
+                    Number(inputAmount) <= 0 || simulation.collateralRatio < 1.2
+                  }
+                  className="w-full"
+                >
+                  <div className={`flex items-center justify-center`}>
+                    {submitting && <Loading className="-ml-1 mr-3" />}
+                    Confirm
+                  </div>
+                </Button>
+              </div>
+              <LinkButton
+                className="flex items-center mt-4 text-th-fgd-3"
+                onClick={() => setShowSimulation(false)}
+              >
+                <ChevronLeftIcon className="h-5 w-5 mr-1" />
+                Back
+              </LinkButton>
+            </>
+          )}
         </>
       ) : (
         <>

--- a/hooks/useAllMarkets.tsx
+++ b/hooks/useAllMarkets.tsx
@@ -1,0 +1,39 @@
+import useConnection from './useConnection'
+import { IDS } from '@blockworks-foundation/mango-client'
+import useMangoStore from '../stores/useMangoStore'
+import { formatTokenMints } from './useMarket'
+
+const useAllMarkets = () => {
+  const markets = useMangoStore((s) => s.selectedMangoGroup.markets)
+  const { cluster, programId } = useConnection()
+  const TOKEN_MINTS = formatTokenMints(IDS[cluster].symbols)
+
+  return Object.keys(markets).map(function (marketIndex) {
+    const market = markets[marketIndex]
+    const marketAddress = market ? market.publicKey.toString() : null
+
+    const baseCurrency =
+      (market?.baseMintAddress &&
+        TOKEN_MINTS.find((token) =>
+          token.address.equals(market.baseMintAddress)
+        )?.name) ||
+      '...'
+
+    const quoteCurrency =
+      (market?.quoteMintAddress &&
+        TOKEN_MINTS.find((token) =>
+          token.address.equals(market.quoteMintAddress)
+        )?.name) ||
+      '...'
+
+    return {
+      market,
+      marketAddress,
+      programId,
+      baseCurrency,
+      quoteCurrency,
+    }
+  })
+}
+
+export default useAllMarkets

--- a/hooks/useBalances.tsx
+++ b/hooks/useBalances.tsx
@@ -1,4 +1,3 @@
-import useMarket from './useMarket'
 import { Balances } from '../@types/types'
 import { nativeToUi } from '@blockworks-foundation/mango-client'
 import useMarketList from './useMarketList'
@@ -8,108 +7,123 @@ import {
   displayDepositsForMarginAccount,
   floorToDecimal,
 } from '../utils'
+import useAllMarkets from './useAllMarkets'
 
 export function useBalances(): Balances[] {
-  const { baseCurrency, quoteCurrency, market } = useMarket()
+  let balances = []
+  const markets = useAllMarkets()
   const mangoGroup = useMangoStore((s) => s.selectedMangoGroup.current)
   const marginAccount = useMangoStore((s) => s.selectedMarginAccount.current)
   const { symbols } = useMarketList()
 
-  if (!marginAccount || !mangoGroup || !market) {
-    return []
-  }
+  for (const { market, baseCurrency, quoteCurrency } of markets) {
+    if (!marginAccount || !mangoGroup || !market) {
+      return []
+    }
 
-  const marketIndex = mangoGroup.getMarketIndex(market)
-  const openOrders: any = marginAccount.openOrdersAccounts[marketIndex]
-  const baseCurrencyIndex = Object.entries(symbols).findIndex(
-    (x) => x[0] === baseCurrency
-  )
-  const quoteCurrencyIndex = Object.entries(symbols).findIndex(
-    (x) => x[0] === quoteCurrency
-  )
-
-  if (
-    baseCurrency === 'UNKNOWN' ||
-    quoteCurrency === 'UNKNOWN' ||
-    !baseCurrency ||
-    !quoteCurrency
-  ) {
-    return []
-  }
-
-  const nativeBaseFree = openOrders?.baseTokenFree || 0
-  const nativeQuoteFree = openOrders?.quoteTokenFree || 0
-
-  const nativeBaseLocked = openOrders
-    ? openOrders.baseTokenTotal - nativeBaseFree
-    : 0
-  const nativeQuoteLocked = openOrders
-    ? openOrders?.quoteTokenTotal - nativeQuoteFree
-    : 0
-
-  const nativeBaseUnsettled = openOrders?.baseTokenFree || 0
-  const nativeQuoteUnsettled = openOrders?.quoteTokenFree || 0
-  const tokenIndex = marketIndex
-
-  const net = (borrows, currencyIndex) => {
-    const amount =
-      marginAccount.getNativeDeposit(mangoGroup, currencyIndex) +
-      borrows -
-      marginAccount.getNativeBorrow(mangoGroup, currencyIndex)
-
-    return floorToDecimal(
-      nativeToUi(amount, mangoGroup.mintDecimals[currencyIndex]),
-      mangoGroup.mintDecimals[currencyIndex]
+    const marketIndex = mangoGroup.getMarketIndex(market)
+    const openOrders: any = marginAccount.openOrdersAccounts[marketIndex]
+    const baseCurrencyIndex = Object.entries(symbols).findIndex(
+      (x) => x[0] === baseCurrency
     )
+    const quoteCurrencyIndex = Object.entries(symbols).findIndex(
+      (x) => x[0] === quoteCurrency
+    )
+
+    if (
+      baseCurrency === 'UNKNOWN' ||
+      quoteCurrency === 'UNKNOWN' ||
+      !baseCurrency ||
+      !quoteCurrency
+    ) {
+      return []
+    }
+
+    const nativeBaseFree = openOrders?.baseTokenFree || 0
+    const nativeQuoteFree = openOrders?.quoteTokenFree || 0
+
+    const nativeBaseLocked = openOrders
+      ? openOrders.baseTokenTotal - nativeBaseFree
+      : 0
+    const nativeQuoteLocked = openOrders
+      ? openOrders?.quoteTokenTotal - nativeQuoteFree
+      : 0
+
+    const nativeBaseUnsettled = openOrders?.baseTokenFree || 0
+    const nativeQuoteUnsettled = openOrders?.quoteTokenFree || 0
+    const tokenIndex = marketIndex
+
+    const net = (borrows, currencyIndex) => {
+      const amount =
+        marginAccount.getNativeDeposit(mangoGroup, currencyIndex) +
+        borrows -
+        marginAccount.getNativeBorrow(mangoGroup, currencyIndex)
+
+      return floorToDecimal(
+        nativeToUi(amount, mangoGroup.mintDecimals[currencyIndex]),
+        mangoGroup.mintDecimals[currencyIndex]
+      )
+    }
+
+    const marketPair = [
+      {
+        market,
+        key: `${baseCurrency}${quoteCurrency}${baseCurrency}`,
+        coin: baseCurrency,
+        marginDeposits: displayDepositsForMarginAccount(
+          marginAccount,
+          mangoGroup,
+          baseCurrencyIndex
+        ),
+        borrows: displayBorrowsForMarginAccount(
+          marginAccount,
+          mangoGroup,
+          baseCurrencyIndex
+        ),
+        orders: nativeToUi(
+          nativeBaseLocked,
+          mangoGroup.mintDecimals[tokenIndex]
+        ),
+        openOrders,
+        unsettled: nativeToUi(
+          nativeBaseUnsettled,
+          mangoGroup.mintDecimals[tokenIndex]
+        ),
+        net: net(nativeBaseLocked, tokenIndex),
+      },
+      {
+        market,
+        key: `${quoteCurrency}${baseCurrency}${quoteCurrency}`,
+        coin: quoteCurrency,
+        marginDeposits: displayDepositsForMarginAccount(
+          marginAccount,
+          mangoGroup,
+          quoteCurrencyIndex
+        ),
+        borrows: displayBorrowsForMarginAccount(
+          marginAccount,
+          mangoGroup,
+          quoteCurrencyIndex
+        ),
+        openOrders,
+        orders: nativeToUi(
+          nativeQuoteLocked,
+          mangoGroup.mintDecimals[quoteCurrencyIndex]
+        ),
+        unsettled: nativeToUi(
+          nativeQuoteUnsettled,
+          mangoGroup.mintDecimals[quoteCurrencyIndex]
+        ),
+        net: net(nativeQuoteLocked, quoteCurrencyIndex),
+      },
+    ]
+    balances = balances.concat(marketPair)
   }
 
-  return [
-    {
-      market,
-      key: `${baseCurrency}${quoteCurrency}${baseCurrency}`,
-      coin: baseCurrency,
-      marginDeposits: displayDepositsForMarginAccount(
-        marginAccount,
-        mangoGroup,
-        baseCurrencyIndex
-      ),
-      borrows: displayBorrowsForMarginAccount(
-        marginAccount,
-        mangoGroup,
-        baseCurrencyIndex
-      ),
-      orders: nativeToUi(nativeBaseLocked, mangoGroup.mintDecimals[tokenIndex]),
-      openOrders,
-      unsettled: nativeToUi(
-        nativeBaseUnsettled,
-        mangoGroup.mintDecimals[tokenIndex]
-      ),
-      net: net(nativeBaseLocked, tokenIndex),
-    },
-    {
-      market,
-      key: `${quoteCurrency}${baseCurrency}${quoteCurrency}`,
-      coin: quoteCurrency,
-      marginDeposits: displayDepositsForMarginAccount(
-        marginAccount,
-        mangoGroup,
-        quoteCurrencyIndex
-      ),
-      borrows: displayBorrowsForMarginAccount(
-        marginAccount,
-        mangoGroup,
-        quoteCurrencyIndex
-      ),
-      openOrders,
-      orders: nativeToUi(
-        nativeQuoteLocked,
-        mangoGroup.mintDecimals[quoteCurrencyIndex]
-      ),
-      unsettled: nativeToUi(
-        nativeQuoteUnsettled,
-        mangoGroup.mintDecimals[quoteCurrencyIndex]
-      ),
-      net: net(nativeQuoteLocked, quoteCurrencyIndex),
-    },
-  ]
+  balances.sort((a, b) => (a.coin > b.coin ? 1 : -1))
+  balances = balances.filter(function (elem, index, self) {
+    return index === self.map((a) => a.coin).indexOf(elem.coin)
+  })
+
+  return balances
 }

--- a/hooks/useMarket.tsx
+++ b/hooks/useMarket.tsx
@@ -4,7 +4,7 @@ import { PublicKey } from '@solana/web3.js'
 import useMangoStore from '../stores/useMangoStore'
 import { IDS } from '@blockworks-foundation/mango-client'
 
-const formatTokenMints = (symbols: { [name: string]: string }) => {
+export const formatTokenMints = (symbols: { [name: string]: string }) => {
   return Object.entries(symbols).map(([name, address]) => {
     return {
       address: new PublicKey(address),

--- a/pages/alerts.tsx
+++ b/pages/alerts.tsx
@@ -17,6 +17,7 @@ import Button, { LinkButton } from '../components/Button'
 import AlertsModal from '../components/AlertsModal'
 import AlertItem from '../components/AlertItem'
 import PageBodyContainer from '../components/PageBodyContainer'
+import Select from '../components/Select'
 import { abbreviateAddress } from '../utils'
 
 const relativeTime = require('dayjs/plugin/relativeTime')
@@ -30,7 +31,7 @@ export default function Alerts() {
   const [activeTab, setActiveTab] = useState(TABS[0])
   const [openAlertModal, setOpenAlertModal] = useState(false)
   const [reactivateAlertData, setReactivateAlertData] = useState(null)
-  const [acc, setAcc] = useState('all')
+  const [acc, setAcc] = useState('All')
   const [filteredActiveAlerts, setFilteredActiveAlerts] = useState([])
   const [filteredTriggeredAlerts, setFilteredTriggeredAlerts] = useState([])
   const activeAlerts = useAlertsStore((s) => s.activeAlerts)
@@ -43,7 +44,7 @@ export default function Alerts() {
 
   useEffect(() => {
     if (!connected || loading) {
-      setAcc('all')
+      setAcc('All')
     }
   }, [connected, loading])
 
@@ -62,9 +63,9 @@ export default function Alerts() {
     setActiveTab(tabName)
   }
 
-  const handleAccountRadioGroupChange = (val) => {
-    setAcc(val)
-    if (val !== 'all') {
+  const handleAccountChange = (val) => {
+    if (val !== 'All') {
+      setAcc(val)
       const showActive = activeAlerts.filter(
         (alert) => alert.acc.toString() === val
       )
@@ -73,6 +74,8 @@ export default function Alerts() {
         : triggeredAlerts.filter((alert) => alert.acc.toString() === val)
       setFilteredActiveAlerts(showActive)
       setFilteredTriggeredAlerts(showTriggered)
+    } else {
+      setAcc(val)
     }
   }
 
@@ -83,14 +86,14 @@ export default function Alerts() {
         <div className="flex flex-col sm:flex-row items-center justify-between pt-8 pb-3 sm:pb-6 md:pt-10">
           <h1 className={`text-th-fgd-1 text-2xl font-semibold`}>Alerts</h1>
           <div className="flex flex-col-reverse justify-between w-full pt-4 sm:pt-0 sm:justify-end sm:flex-row">
-            {marginAccounts.length > 1 ? (
+            {marginAccounts.length === 2 ? (
               <RadioGroup
                 value={acc.toString()}
-                onChange={(val) => handleAccountRadioGroupChange(val)}
+                onChange={(val) => handleAccountChange(val)}
                 className="flex border border-th-fgd-4 rounded-md w-full mt-3 sm:mt-0 sm:w-80 h-full text-xs h-8"
               >
                 <RadioGroup.Option
-                  value="all"
+                  value="All"
                   className="flex-1 focus:outline-none"
                 >
                   {({ checked }) => (
@@ -133,8 +136,35 @@ export default function Alerts() {
                   ))}
               </RadioGroup>
             ) : null}
+            {marginAccounts.length > 2 ? (
+              <Select
+                className="w-full mt-2 sm:w-36 sm:mt-0"
+                value={
+                  acc === 'All'
+                    ? 'All'
+                    : `${acc.slice(0, 5)}...${acc.slice(-5)}`
+                }
+                onChange={(val) => handleAccountChange(val)}
+              >
+                <Select.Option value="All">All</Select.Option>
+                {marginAccounts
+                  .slice()
+                  .sort(
+                    (a, b) =>
+                      (a.publicKey.toBase58() > b.publicKey.toBase58() && 1) ||
+                      -1
+                  )
+                  .map((acc, i) => (
+                    <Select.Option key={i} value={acc.publicKey.toString()}>
+                      {abbreviateAddress(acc.publicKey)}
+                    </Select.Option>
+                  ))}
+              </Select>
+            ) : null}
             <Button
-              className="text-xs flex items-center justify-center sm:ml-2 pt-0 pb-0 h-8 pl-3 pr-3"
+              className={`text-xs flex items-center justify-center sm:ml-2 pt-0 pb-0 ${
+                marginAccounts.length > 2 ? 'h-10' : 'h-8'
+              } pl-3 pr-3`}
               disabled={!connected}
               onClick={() => setOpenAlertModal(true)}
             >
@@ -241,7 +271,7 @@ const TabContent = ({
               Active alerts will only trigger once.
             </p>
           </div>
-          {acc === 'all'
+          {acc === 'All'
             ? activeAlerts.map((alert) => (
                 <AlertItem alert={alert} key={alert.timestamp} isLarge />
               ))
@@ -255,7 +285,7 @@ const TabContent = ({
         <div>
           {triggeredAlerts.length === 0 ||
           (clearAlertsTimestamp && clearedAlerts.length === 0) ||
-          (acc !== 'all' && filteredTriggeredAlerts.length === 0) ? (
+          (acc !== 'All' && filteredTriggeredAlerts.length === 0) ? (
             <div className="flex flex-col items-center text-th-fgd-1 px-4 pb-2 rounded-lg">
               <BadgeCheckIcon className="w-6 h-6 mb-1 text-th-green" />
               <div className="font-bold text-lg pb-1">Smooth Sailing</div>
@@ -285,7 +315,7 @@ const TabContent = ({
                   </div>
                 </LinkButton>
               </div>
-              {acc === 'all'
+              {acc === 'All'
                 ? clearAlertsTimestamp
                   ? clearedAlerts.map((alert) => (
                       <AlertItem

--- a/pages/stats.tsx
+++ b/pages/stats.tsx
@@ -6,15 +6,8 @@ import { PublicKey, Connection } from '@solana/web3.js'
 import { DEFAULT_MANGO_GROUP } from '../utils/mango'
 import useConnection from '../hooks/useConnection'
 import TopBar from '../components/TopBar'
-import { formatBalanceDisplay } from '../utils/index'
+import { formatBalanceDisplay, tokenPrecision } from '../utils/index'
 import { Table, Thead, Tbody, Tr, Th, Td } from 'react-super-responsive-table'
-
-const DECIMALS = {
-  BTC: 4,
-  ETH: 3,
-  USDT: 2,
-  USDC: 2,
-}
 
 const icons = {
   BTC: '/assets/icons/btc.svg',
@@ -227,17 +220,17 @@ export default function StatsPage() {
                   <Td className="px-6 py-4 whitespace-nowrap text-sm text-th-fgd-1">
                     {formatBalanceDisplay(
                       stat.totalDeposits,
-                      DECIMALS[stat.symbol]
+                      tokenPrecision[stat.symbol]
                     ).toLocaleString(undefined, {
-                      maximumFractionDigits: DECIMALS[stat.symbol],
+                      maximumFractionDigits: tokenPrecision[stat.symbol],
                     })}
                   </Td>
                   <Td className="px-6 py-4 whitespace-nowrap text-sm text-th-fgd-1">
                     {formatBalanceDisplay(
                       stat.totalBorrows,
-                      DECIMALS[stat.symbol]
+                      tokenPrecision[stat.symbol]
                     ).toLocaleString(undefined, {
-                      maximumFractionDigits: DECIMALS[stat.symbol],
+                      maximumFractionDigits: tokenPrecision[stat.symbol],
                     })}
                   </Td>
                   <Td className="px-6 py-4 whitespace-nowrap text-sm text-th-fgd-1">
@@ -288,7 +281,7 @@ export default function StatsPage() {
                   xAxis="time"
                   yAxis="totalDeposits"
                   data={selectedStatsData}
-                  labelFormat={(x) => x.toFixed(DECIMALS[selectedAsset])}
+                  labelFormat={(x) => x.toFixed(tokenPrecision[selectedAsset])}
                 />
               </div>
               <div
@@ -300,7 +293,7 @@ export default function StatsPage() {
                   xAxis="time"
                   yAxis="totalBorrows"
                   data={selectedStatsData}
-                  labelFormat={(x) => x.toFixed(DECIMALS[selectedAsset])}
+                  labelFormat={(x) => x.toFixed(tokenPrecision[selectedAsset])}
                 />
               </div>
             </div>

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -174,6 +174,15 @@ export const tokenPrecision = {
   WUSDT: 2,
 }
 
+// Precision for depositing/withdrawing
+export const DECIMALS = {
+  BTC: 5,
+  ETH: 4,
+  USDC: 2,
+  USDT: 2,
+  WUSDT: 2,
+}
+
 export const getSymbolForTokenMintAddress = (address: string): string => {
   if (address && address.length) {
     return TOKEN_MINTS.find((m) => m.address.toString() === address)?.name || ''
@@ -194,4 +203,12 @@ export const copyToClipboard = (copyThis) => {
   el.select()
   document.execCommand('copy')
   document.body.removeChild(el)
+}
+
+// Truncate decimals without rounding
+export const trimDecimals = (n, digits) => {
+  var step = Math.pow(10, digits || 0)
+  var temp = Math.trunc(step * n)
+
+  return temp / step
 }


### PR DESCRIPTION
This pull request adds functionality requested in the Mango Markets Trello Backlog (28-trade-input-form-bugs):

1) Allow users to type '.01' in trade form instead of requiring '0.01'
*Problem:* The **parseFloat** function checks the first character to determine if an input is numeric, which currently results in a NaN error if numerical gramma (+-,.) is the initial character.<br>
*Soution:* **Add an if statement** to the input handlers to determine if there is grammatical notation (such as '.') and delay calling parseFloat until there is valid numerical input to parse (such as '.1'). <br><br><br>
2) USDT field won't accept 1 as an input
*Problem 1:* The rounding method (roundToDecimal) allows USDT orders at half the minimum order size to be executed (backend debits correctly, but not warning is given to the user). <br>
*Solution 1:* Replace **roundToDecimal** with **floorToDecimal** to ensure minimum order size is met for an order to execute.<br>
*Problem 2:* 1 USDT is currently below minimum order size (at current Market Price).<br>
*Solution 2:* This is correct functionality at current Market Price and should not be changed. Where a Limit Order is used, it is possible to purchase 1 USDT worth of the selected token if 1 USDT is greater than the minimum order size. Buy/Sell prompt has been updated to alert user of the minimum order size. <br>
<p>
Videos of Solutions In Action:<br>

https://user-images.githubusercontent.com/47860274/121122995-543b4a80-c7d7-11eb-9328-34e97b4f276d.mp4

https://user-images.githubusercontent.com/47860274/121123006-57363b00-c7d7-11eb-833b-3b5b8b94759c.mp4


