### PR TITLE
Updated TradeForm.tsx UI Bugs

### DIFF
--- a/components/TradeForm.tsx
+++ b/components/TradeForm.tsx
@@ -9,7 +9,7 @@ import { notify } from '../utils/notifications'
 import { placeAndSettle } from '../utils/mango'
 import { calculateMarketPrice, getDecimalCount } from '../utils'
 import FloatingElement from './FloatingElement'
-import { roundToDecimal } from '../utils/index'
+import { floorToDecimal } from '../utils/index'
 import useMangoStore from '../stores/useMangoStore'
 import Button from './Button'
 import TradeType from './TradeType'
@@ -52,17 +52,29 @@ export default function TradeForm() {
 
   const setBaseSize = (baseSize) =>
     set((s) => {
-      s.tradeForm.baseSize = parseFloat(baseSize)
+      if (!Number.isNaN(parseFloat(baseSize))) {
+        s.tradeForm.baseSize = parseFloat(baseSize)
+      } else {
+        s.tradeForm.baseSize = baseSize
+      }
     })
 
   const setQuoteSize = (quoteSize) =>
     set((s) => {
-      s.tradeForm.quoteSize = parseFloat(quoteSize)
+      if (!Number.isNaN(parseFloat(quoteSize))) {
+        s.tradeForm.quoteSize = parseFloat(quoteSize)
+      } else {
+        s.tradeForm.quoteSize = quoteSize
+      }
     })
 
   const setPrice = (price) =>
     set((s) => {
-      s.tradeForm.price = parseFloat(price)
+      if (!Number.isNaN(parseFloat(price))) {
+        s.tradeForm.price = parseFloat(price)
+      } else {
+        s.tradeForm.price = price
+      }
     })
 
   const setTradeType = (type) =>
@@ -106,7 +118,7 @@ export default function TradeForm() {
       return
     }
     const rawQuoteSize = baseSize * usePrice
-    const quoteSize = baseSize && roundToDecimal(rawQuoteSize, sizeDecimalCount)
+    const quoteSize = baseSize && floorToDecimal(rawQuoteSize, sizeDecimalCount)
     setQuoteSize(quoteSize)
   }
 
@@ -123,7 +135,7 @@ export default function TradeForm() {
     }
     const usePrice = Number(price) || markPrice
     const rawBaseSize = quoteSize / usePrice
-    const baseSize = quoteSize && roundToDecimal(rawBaseSize, sizeDecimalCount)
+    const baseSize = quoteSize && floorToDecimal(rawBaseSize, sizeDecimalCount)
     setBaseSize(baseSize)
   }
 
@@ -255,8 +267,9 @@ export default function TradeForm() {
         <Input.Group className="mt-4">
           <Input
             type="number"
+            min="0"
             step={market?.tickSize || 1}
-            onChange={(e) => onSetPrice(parseFloat(e.target.value))}
+            onChange={(e) => onSetPrice(e.target.value)}
             value={price}
             disabled={tradeType === 'Market'}
             prefix={'Price'}
@@ -274,8 +287,9 @@ export default function TradeForm() {
         <Input.Group className="mt-4">
           <Input
             type="number"
+            min="0"
             step={market?.minOrderSize || 1}
-            onChange={(e) => onSetBaseSize(parseFloat(e.target.value))}
+            onChange={(e) => onSetBaseSize(e.target.value)}
             value={baseSize}
             className="rounded-r-none"
             wrapperClassName="w-3/5"
@@ -284,8 +298,9 @@ export default function TradeForm() {
           />
           <StyledRightInput
             type="number"
+            min="0"
             step={market?.minOrderSize || 1}
-            onChange={(e) => onSetQuoteSize(parseFloat(e.target.value))}
+            onChange={(e) => onSetQuoteSize(e.target.value)}
             value={quoteSize}
             className="rounded-l-none"
             wrapperClassName="w-2/5"
@@ -317,7 +332,7 @@ export default function TradeForm() {
                   'border-th-green hover:border-th-green-dark'
                 } text-th-green hover:text-th-fgd-1 hover:bg-th-green-dark flex-grow`}
               >
-                {`Buy ${baseSize > 0 ? baseSize : ''} ${baseCurrency}`}
+                {`${baseSize > 0 ? 'Buy ' + baseSize : 'Set BUY bid >= ' + market?.minOrderSize} ${baseCurrency}`}
               </Button>
             ) : (
               <Button
@@ -328,7 +343,7 @@ export default function TradeForm() {
                   'border-th-red hover:border-th-red-dark'
                 } text-th-red hover:text-th-fgd-1 hover:bg-th-red-dark flex-grow`}
               >
-                {`Sell ${baseSize > 0 ? baseSize : ''} ${baseCurrency}`}
+                {`${baseSize > 0 ? 'Sell ' + baseSize : 'Set SELL bid >= ' + market?.minOrderSize} ${baseCurrency}`}
               </Button>
             )
           ) : (


### PR DESCRIPTION
TL;DR - Added handling of USDT orders below minimum size (e.g. $1), removed ability to execute trades at half minimum order size due to rounding, and added allowance for user input leading with numerical input that is not strictly a number (e.g. decimal point) by delaying parseFloat until a number is present.

Detailed:
This pull request adds functionality requested in the Mango Markets Trello Backlog (28-trade-input-form-bugs):

1. Allow users to type '.01' in trade form instead of requiring '0.01'
*Problem:* The parseFloat function checks the first character to determine if an input is numeric, which currently results in a NaN error if numerical gramma (+-,.) is the initial character.<br><br>*Solution:* Add an if statement to the input handlers to determine if there is grammatical notation (such as '.') and delay calling parseFloat until there is valid numerical input to parse (such as '.1').
<p><br>

2. USDT field won't accept 1 as an input
*Problem 1:* The rounding method (roundToDecimal) allows USDT orders at half the minimum order size to be executed (backend debits correctly, but not warning is given to the user).<br><br>*Solution 1:* Replace roundToDecimal with floorToDecimal to ensure minimum order size is met for an order to execute.<br><br>*Problem 2:* 1 USDT is currently below minimum order size (at current Market Price).<br><br>*Solution 2:* This is correct functionality at current Market Price and should not be changed. Where a Limit Order is used, it is possible to purchase 1 USDT worth of the selected token if 1 USDT is greater than the minimum order size. Buy/Sell prompt has been updated to alert user of the minimum order size.<p>
Videos of Solutions In Action:

https://user-images.githubusercontent.com/47860274/121438356-c1b2bc80-c938-11eb-91e7-93b537bd079f.mp4

https://user-images.githubusercontent.com/47860274/121438377-c8413400-c938-11eb-9dc0-564bc57f71e5.mp4


