### PR TITLE
Validate min-size and fix misaligned trade page layout

### DIFF
--- a/components/TradeForm.tsx
+++ b/components/TradeForm.tsx
@@ -55,7 +55,7 @@ export default function TradeForm() {
   }, [baseCurrency])
 
   useEffect(() => {
-    if (market && baseSize > market.minOrderSize) {
+    if (market && baseSize >= market.minOrderSize) {
       setInvalidInputMessage('')
     }
   }, [baseSize])
@@ -257,7 +257,7 @@ export default function TradeForm() {
   }
 
   const validateInput = () => {
-    if (baseSize < market.minOrderSize) {
+    if (market && baseSize < market.minOrderSize) {
       setInvalidInputMessage(
         `Size must be greater than or equal to ${market.minOrderSize} ${baseCurrency}`
       )
@@ -267,7 +267,7 @@ export default function TradeForm() {
   const disabledTradeButton =
     (!price && tradeType === 'Limit') ||
     !baseSize ||
-    baseSize < market.minOrderSize ||
+    (market && baseSize < market.minOrderSize) ||
     !connected ||
     submitting
 

--- a/components/TradeForm.tsx
+++ b/components/TradeForm.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
+import { ExclamationCircleIcon } from '@heroicons/react/outline'
 import styled from '@emotion/styled'
 import useMarket from '../hooks/useMarket'
 import useIpAddress from '../hooks/useIpAddress'
@@ -30,6 +31,7 @@ export default function TradeForm() {
     (s) => s.tradeForm
   )
   const { ipAllowed } = useIpAddress()
+  const [invalidInputMessage, setInvalidInputMessage] = useState('')
   const [postOnly, setPostOnly] = useState(false)
   const [ioc, setIoc] = useState(false)
   const [submitting, setSubmitting] = useState(false)
@@ -44,6 +46,33 @@ export default function TradeForm() {
       ),
     []
   )
+
+  useEffect(() => {
+    setBaseSize('')
+    setInvalidInputMessage('')
+    setPrice('')
+    setQuoteSize('')
+  }, [baseCurrency])
+
+  useEffect(() => {
+    if (baseSize > market.minOrderSize) {
+      setInvalidInputMessage('')
+    }
+  }, [baseSize])
+
+  useEffect(() => {
+    const usePrice = tradeType === 'Limit' ? Number(price) : markPrice
+    if (baseSize) {
+      const rawQuoteSize = Number(baseSize) * usePrice
+      const quoteSize = floorToDecimal(rawQuoteSize, sizeDecimalCount)
+      setQuoteSize(quoteSize)
+    }
+    if (quoteSize && usePrice && !baseSize) {
+      const rawBaseSize = quoteSize / usePrice
+      const baseSize = floorToDecimal(rawBaseSize, sizeDecimalCount)
+      setBaseSize(baseSize)
+    }
+  }, [price, tradeType])
 
   const setSide = (side) =>
     set((s) => {
@@ -227,19 +256,31 @@ export default function TradeForm() {
     }
   }
 
+  const validateInput = () => {
+    if (baseSize < market.minOrderSize) {
+      setInvalidInputMessage(
+        `Size must be greater than or equal to ${market.minOrderSize} ${baseCurrency}`
+      )
+    }
+  }
+
   const disabledTradeButton =
-    (!price && tradeType === 'Limit') || !baseSize || !connected || submitting
+    (!price && tradeType === 'Limit') ||
+    !baseSize ||
+    baseSize < market.minOrderSize ||
+    !connected ||
+    submitting
 
   return (
     <FloatingElement>
       <div>
-        <div className={`flex text-base text-th-fgd-4`}>
+        <div className={`flex mb-4 text-base text-th-fgd-4`}>
           <button
             onClick={() => setSide('buy')}
             className={`flex-1 outline-none focus:outline-none`}
           >
             <div
-              className={`hover:text-th-green pb-1 transition-colors duration-500
+              className={`border-b-2 border-th-bkg-3 hover:text-th-green pb-2 transition-colors duration-500
                 ${
                   side === 'buy' &&
                   `text-th-green hover:text-th-green border-b-2 border-th-green`
@@ -253,7 +294,7 @@ export default function TradeForm() {
             className={`flex-1 outline-none focus:outline-none`}
           >
             <div
-              className={`hover:text-th-red pb-1 transition-colors duration-500
+              className={`border-b-2 border-th-bkg-3 hover:text-th-red pb-2 transition-colors duration-500
                 ${
                   side === 'sell' &&
                   `text-th-red hover:text-th-red border-b-2 border-th-red`
@@ -264,7 +305,7 @@ export default function TradeForm() {
             </div>
           </button>
         </div>
-        <Input.Group className="mt-4">
+        <Input.Group className="mt-2">
           <Input
             type="number"
             min="0"
@@ -289,6 +330,7 @@ export default function TradeForm() {
             type="number"
             min="0"
             step={market?.minOrderSize || 1}
+            onBlur={() => validateInput()}
             onChange={(e) => onSetBaseSize(e.target.value)}
             value={baseSize}
             className="rounded-r-none"
@@ -300,6 +342,7 @@ export default function TradeForm() {
             type="number"
             min="0"
             step={market?.minOrderSize || 1}
+            onBlur={() => validateInput()}
             onChange={(e) => onSetQuoteSize(e.target.value)}
             value={quoteSize}
             className="rounded-l-none"
@@ -307,6 +350,12 @@ export default function TradeForm() {
             suffix={quoteCurrency}
           />
         </Input.Group>
+        {invalidInputMessage ? (
+          <div className="flex items-center pt-1.5 text-th-red">
+            <ExclamationCircleIcon className="h-4 w-4 mr-1.5" />
+            {invalidInputMessage}
+          </div>
+        ) : null}
         {tradeType !== 'Market' ? (
           <div className="flex items-center mt-4">
             <Switch checked={postOnly} onChange={postOnChange}>
@@ -332,7 +381,7 @@ export default function TradeForm() {
                   'border-th-green hover:border-th-green-dark'
                 } text-th-green hover:text-th-fgd-1 hover:bg-th-green-dark flex-grow`}
               >
-                {`${baseSize > 0 ? 'Buy ' + baseSize : 'Set BUY bid >= ' + market?.minOrderSize} ${baseCurrency}`}
+                {`${baseSize > 0 ? 'Buy ' + baseSize : 'Buy'} ${baseCurrency}`}
               </Button>
             ) : (
               <Button
@@ -343,7 +392,9 @@ export default function TradeForm() {
                   'border-th-red hover:border-th-red-dark'
                 } text-th-red hover:text-th-fgd-1 hover:bg-th-red-dark flex-grow`}
               >
-                {`${baseSize > 0 ? 'Sell ' + baseSize : 'Set SELL bid >= ' + market?.minOrderSize} ${baseCurrency}`}
+                {`${
+                  baseSize > 0 ? 'Sell ' + baseSize : 'Sell'
+                } ${baseCurrency}`}
               </Button>
             )
           ) : (

--- a/components/TradePageGrid.tsx
+++ b/components/TradePageGrid.tsx
@@ -22,14 +22,14 @@ export const defaultLayouts = {
   xl: [
     { i: 'tvChart', x: 0, y: 0, w: 6, h: 30 },
     { i: 'orderbook', x: 6, y: 0, w: 3, h: 17 },
-    { i: 'tradeForm', x: 9, y: 0, w: 3, h: 12 },
+    { i: 'tradeForm', x: 9, y: 0, w: 3, h: 13 },
     { i: 'marketTrades', x: 6, y: 1, w: 3, h: 13 },
     { i: 'balanceInfo', x: 9, y: 1, w: 3, h: 15 },
     { i: 'userInfo', x: 0, y: 2, w: 9, h: 18 },
     { i: 'marginInfo', x: 9, y: 2, w: 3, h: 13 },
   ],
   lg: [
-    { i: 'tvChart', x: 0, y: 0, w: 8, h: 26, minW: 2 },
+    { i: 'tvChart', x: 0, y: 0, w: 8, h: 28, minW: 2 },
     { i: 'balanceInfo', x: 8, y: 0, w: 4, h: 15, minW: 2 },
     { i: 'marginInfo', x: 8, y: 1, w: 4, h: 13, minW: 2 },
     { i: 'orderbook', x: 0, y: 2, w: 4, h: 17, minW: 2 },
@@ -38,7 +38,7 @@ export const defaultLayouts = {
     { i: 'userInfo', x: 0, y: 3, w: 12, h: 18, minW: 6 },
   ],
   md: [
-    { i: 'tvChart', x: 0, y: 0, w: 8, h: 26, minW: 2 },
+    { i: 'tvChart', x: 0, y: 0, w: 8, h: 28, minW: 2 },
     { i: 'balanceInfo', x: 8, y: 0, w: 4, h: 15, minW: 2 },
     { i: 'marginInfo', x: 8, y: 1, w: 4, h: 13, minW: 2 },
     { i: 'orderbook', x: 0, y: 2, w: 4, h: 17, minW: 2 },
@@ -49,7 +49,7 @@ export const defaultLayouts = {
   sm: [
     { i: 'tvChart', x: 0, y: 0, w: 12, h: 25, minW: 6 },
     { i: 'balanceInfo', x: 0, y: 1, w: 6, h: 15, minW: 2 },
-    { i: 'marginInfo', x: 6, y: 1, w: 6, h: 13, minW: 2 },
+    { i: 'marginInfo', x: 6, y: 1, w: 6, h: 15, minW: 2 },
     { i: 'tradeForm', x: 0, y: 2, w: 12, h: 13, minW: 3 },
     { i: 'orderbook', x: 0, y: 3, w: 6, h: 17, minW: 3 },
     { i: 'marketTrades', x: 6, y: 3, w: 6, h: 17, minW: 2 },


### PR DESCRIPTION
Show an error onBlur of input when a user enters a trade size below the market min. Also noticed the default layout was not aligned on a couple of breakpoints so a fix for that is with this too.