### PR TITLE
Updated Margin Info To Be More Actionable

### DIFF
--- a/components/MarginInfo.tsx
+++ b/components/MarginInfo.tsx
@@ -81,8 +81,8 @@ export default function MarginInfo() {
           ? selectedMarginAccount.getCollateralRatio(
               selectedMangoGroup,
               prices
-            ) || 200
-          : 200
+            ) || 0
+          : 0
 
         const accountEquity = selectedMarginAccount
           ? selectedMarginAccount.computeValue(selectedMangoGroup, prices)
@@ -129,24 +129,30 @@ export default function MarginInfo() {
             // TODO: Get collaterization ratio
             label: 'Collateral Ratio',
             value:
-              collateralRatio > 2 ? '>200' : (100 * collateralRatio).toFixed(0),
+              collateralRatio <= 0
+                ? 'N/A '
+                : (100 * collateralRatio).toFixed(0),
             unit: '%',
             currency: '',
             desc: 'The current collateral ratio',
           },
           {
-            label: 'Maint. Collateral Ratio',
-            value: (selectedMangoGroup.maintCollRatio * 100).toFixed(0),
-            unit: '%',
-            currency: '',
-            desc: 'The collateral ratio you must maintain to not get liquidated',
+            label: 'Minimum Collateral Required',
+            value: (
+              selectedMangoGroup.maintCollRatio *
+              leverage *
+              accountEquity
+            ).toFixed(2),
+            unit: '',
+            currency: '$',
+            desc: 'The collateral you must maintain to not get liquidated (Maintenance Collateral Ratio = 110%)',
           },
           {
-            label: 'Initial Collateral Ratio',
-            value: (selectedMangoGroup.initCollRatio * 100).toFixed(0),
-            currency: '',
-            unit: '%',
-            desc: 'The collateral ratio required to open a new margin position',
+            label: 'Current Collateral Available',
+            value: (accountEquity + accountEquity * leverage).toFixed(2),
+            unit: '',
+            currency: '$',
+            desc: 'The collateral available to protect margin position',
           },
         ])
       })


### PR DESCRIPTION
Minor UI update to provide more actionable information on Margin Collateral Information.

Collateral references have been updated to display in $ terms and precise margin % as this is more actionable and has been requested by quite a few users. There is still a reference to the minimum MCR % in the tooltip. 

This would be an interim step to a full featured liquidation calculator, but should be helpful to users whilst that is in development.

Please let me know if any updates are required.

![Margin_Information_Default_Update](https://user-images.githubusercontent.com/47860274/122600849-42eb0d00-d025-11eb-8512-34052555e17c.png)
![Margin_Information_InUse_Update](https://user-images.githubusercontent.com/47860274/122600865-44b4d080-d025-11eb-86d5-82c9113e0510.png)
