### PR TITLE
UI margin information

### DIFF
--- a/components/MarginInfo.tsx
+++ b/components/MarginInfo.tsx
@@ -81,8 +81,8 @@ export default function MarginInfo() {
           ? selectedMarginAccount.getCollateralRatio(
               selectedMangoGroup,
               prices
-            ) || 200
-          : 200
+            ) || 0
+          : 0
 
         const accountEquity = selectedMarginAccount
           ? selectedMarginAccount.computeValue(selectedMangoGroup, prices)
@@ -129,24 +129,30 @@ export default function MarginInfo() {
             // TODO: Get collaterization ratio
             label: 'Collateral Ratio',
             value:
-              collateralRatio > 2 ? '>200' : (100 * collateralRatio).toFixed(0),
+              collateralRatio <= 0
+                ? 'N/A '
+                : (100 * collateralRatio).toFixed(0),
             unit: '%',
             currency: '',
             desc: 'The current collateral ratio',
           },
           {
-            label: 'Maint. Collateral Ratio',
-            value: (selectedMangoGroup.maintCollRatio * 100).toFixed(0),
-            unit: '%',
-            currency: '',
-            desc: 'The collateral ratio you must maintain to not get liquidated',
+            label: 'Minimum Collateral Required',
+            value: (
+              selectedMangoGroup.maintCollRatio *
+              leverage *
+              accountEquity
+            ).toFixed(2),
+            unit: '',
+            currency: '$',
+            desc: 'The collateral you must maintain to not get liquidated (Maintenance Collateral Ratio = 110%)',
           },
           {
-            label: 'Initial Collateral Ratio',
-            value: (selectedMangoGroup.initCollRatio * 100).toFixed(0),
-            currency: '',
-            unit: '%',
-            desc: 'The collateral ratio required to open a new margin position',
+            label: 'Current Collateral Available',
+            value: (accountEquity + accountEquity * leverage).toFixed(2),
+            unit: '',
+            currency: '$',
+            desc: 'The collateral available to protect margin position',
           },
         ])
       })

--- a/components/MarginInfo.tsx
+++ b/components/MarginInfo.tsx
@@ -77,7 +77,6 @@ export default function MarginInfo() {
   useEffect(() => {
     if (selectedMangoGroup) {
       selectedMangoGroup.getPrices(connection).then((prices) => {
-
         const accountEquity = selectedMarginAccount
           ? selectedMarginAccount.computeValue(selectedMangoGroup, prices)
           : 0
@@ -86,13 +85,13 @@ export default function MarginInfo() {
         if (selectedMarginAccount) {
           leverage = accountEquity
             ? (
-              1 /
-              (selectedMarginAccount.getCollateralRatio(
-                selectedMangoGroup,
-                prices
-              ) -
-                1)
-            ).toFixed(2)
+                1 /
+                (selectedMarginAccount.getCollateralRatio(
+                  selectedMangoGroup,
+                  prices
+                ) -
+                  1)
+              ).toFixed(2)
             : '0'
         } else {
           leverage = '0'
@@ -100,27 +99,26 @@ export default function MarginInfo() {
 
         const accountCollateralRatioCurrent = selectedMarginAccount
           ? selectedMarginAccount.getCollateralRatio(
-            selectedMangoGroup,
-            prices
-          ) > 100 ?
-            '>10000'
-            :
-            (selectedMarginAccount.getCollateralRatio(
               selectedMangoGroup,
               prices
-            ) * 100).toFixed(0) || 0
+            ) > 100
+            ? '>10000'
+            : (
+                selectedMarginAccount.getCollateralRatio(
+                  selectedMangoGroup,
+                  prices
+                ) * 100
+              ).toFixed(0) || 0
           : 0
 
         const accountCollateralCurrent = selectedMarginAccount
-          ? selectedMarginAccount.getAssetsVal(
-            selectedMangoGroup,
-            prices)
+          ? selectedMarginAccount.getAssetsVal(selectedMangoGroup, prices)
           : 0
 
         const accountCollateralRequired = selectedMarginAccount
-          ? (selectedMarginAccount.getAssetsVal(
-            selectedMangoGroup,
-            prices) - accountEquity) * (selectedMangoGroup.maintCollRatio / 100)
+          ? (selectedMarginAccount.getAssetsVal(selectedMangoGroup, prices) -
+              accountEquity) *
+            selectedMangoGroup.maintCollRatio
           : 0
 
         setMAccountInfo([


### PR DESCRIPTION
Minor UI update to provide more actionable information on Margin Collateral Information and some code tidy-up (moving formulas to the top for better visibility).

Collateral references have been updated to display in $ terms and precise margin % (Capped at 10000% which equals the smallest visible margin position of 0.01x) as this is more actionable and has been requested by quite a few users. There is still a reference to the minimum MCR % in the tooltip for clarity.

This would be an interim step to a full featured liquidation calculator, but should be helpful to users whilst that is in development.

Screenshot comparisons for Default, Margined, and Dust Borrows conditions:

![image](https://user-images.githubusercontent.com/47860274/122650374-4fd03500-d0e7-11eb-803b-4ef3da2cba24.png)
![image](https://user-images.githubusercontent.com/47860274/122650377-58287000-d0e7-11eb-99e0-0c70318d2253.png)
![image](https://user-images.githubusercontent.com/47860274/122650383-5f4f7e00-d0e7-11eb-9c1c-7fda1a0287d7.png)

Please let me know if any updates are required.