### PR TITLE
Add account names

### DIFF
--- a/components/AccountNameForm.tsx
+++ b/components/AccountNameForm.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent, useState } from 'react'
 import useMangoStore from '../stores/useMangoStore'
 import useLocalStorageState from '../hooks/useLocalStorageState'
+import { ExclamationCircleIcon } from '@heroicons/react/outline'
 import Input from './Input'
 import Button from './Button'
 
@@ -14,6 +15,7 @@ const AccountNameForm: FunctionComponent<AccountNameFormProps> = ({
   onClose,
 }) => {
   const [name, setName] = useState(accountName || '')
+  const [invalidNameMessage, setInvalidNameMessage] = useState('')
   const selectedMarginAccount = useMangoStore(
     (s) => s.selectedMarginAccount.current
   )
@@ -40,18 +42,40 @@ const AccountNameForm: FunctionComponent<AccountNameFormProps> = ({
     onClose()
   }
 
+  const validateNameInput = () => {
+    if (name.length >= 25) {
+      setInvalidNameMessage('Account name nust be less than 25 characters')
+    }
+    if (name.length === 0) {
+      setInvalidNameMessage('Enter an account name')
+    }
+  }
+
+  const onChangeNameInput = (name) => {
+    setName(name)
+    if (invalidNameMessage) {
+      setInvalidNameMessage('')
+    }
+  }
+
   return (
     <>
       <div className="pb-2 text-th-fgd-1">Account Name</div>
       <Input
         type="text"
         className={`border border-th-fgd-4 flex-grow`}
-        //   error={!!invalidNameMessage}
+        error={!!invalidNameMessage}
         placeholder="e.g. Calypso"
         value={name}
-        //   onBlur={validateNameInput}
-        onChange={(e) => setName(e.target.value)}
+        onBlur={validateNameInput}
+        onChange={(e) => onChangeNameInput(e.target.value)}
       />
+      {invalidNameMessage ? (
+        <div className="flex items-center pt-1.5 text-th-red">
+          <ExclamationCircleIcon className="h-4 w-4 mr-1.5" />
+          {invalidNameMessage}
+        </div>
+      ) : null}
       <Button
         onClick={() => submitName()}
         disabled={null}

--- a/components/AccountNameForm.tsx
+++ b/components/AccountNameForm.tsx
@@ -1,0 +1,66 @@
+import { FunctionComponent, useState } from 'react'
+import useMangoStore from '../stores/useMangoStore'
+import useLocalStorageState from '../hooks/useLocalStorageState'
+import Input from './Input'
+import Button from './Button'
+
+interface AccountNameFormProps {
+  accountName?: string
+  onClose?: (x?) => void
+}
+
+const AccountNameForm: FunctionComponent<AccountNameFormProps> = ({
+  accountName,
+  onClose,
+}) => {
+  const [name, setName] = useState(accountName || '')
+  const selectedMarginAccount = useMangoStore(
+    (s) => s.selectedMarginAccount.current
+  )
+  const [accountNames, setAccountNames] = useLocalStorageState('accountNames')
+
+  const submitName = () => {
+    const nameAccount = {
+      publicKey: selectedMarginAccount.publicKey.toString(),
+      name: name,
+    }
+    if (accountNames) {
+      const hasName = accountNames.find(
+        (acc) => acc.publicKey === selectedMarginAccount.publicKey.toString()
+      )
+      if (!hasName) {
+        accountNames.push(nameAccount)
+      } else {
+        hasName.name = name
+      }
+      setAccountNames(accountNames)
+    } else {
+      setAccountNames([nameAccount])
+    }
+    onClose()
+  }
+
+  return (
+    <>
+      <div className="pb-2 text-th-fgd-1">Account Name</div>
+      <Input
+        type="text"
+        className={`border border-th-fgd-4 flex-grow`}
+        //   error={!!invalidNameMessage}
+        placeholder="e.g. Calypso"
+        value={name}
+        //   onBlur={validateNameInput}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <Button
+        onClick={() => submitName()}
+        disabled={null}
+        className="mt-4 w-full"
+      >
+        Save Name
+      </Button>
+    </>
+  )
+}
+
+export default AccountNameForm

--- a/components/AccountNameModal.tsx
+++ b/components/AccountNameModal.tsx
@@ -1,17 +1,25 @@
 import { FunctionComponent, useState } from 'react'
 import useMangoStore from '../stores/useMangoStore'
 import useLocalStorageState from '../hooks/useLocalStorageState'
-import { ExclamationCircleIcon } from '@heroicons/react/outline'
+import {
+  ExclamationCircleIcon,
+  InformationCircleIcon,
+} from '@heroicons/react/outline'
 import Input from './Input'
 import Button from './Button'
+import Modal from './Modal'
+import { ElementTitle } from './styles'
+import Tooltip from './Tooltip'
 
-interface AccountNameFormProps {
+interface AccountNameModalProps {
   accountName?: string
+  isOpen: boolean
   onClose?: (x?) => void
 }
 
-const AccountNameForm: FunctionComponent<AccountNameFormProps> = ({
+const AccountNameModal: FunctionComponent<AccountNameModalProps> = ({
   accountName,
+  isOpen,
   onClose,
 }) => {
   const [name, setName] = useState(accountName || '')
@@ -59,7 +67,15 @@ const AccountNameForm: FunctionComponent<AccountNameFormProps> = ({
   }
 
   return (
-    <>
+    <Modal onClose={onClose} isOpen={isOpen}>
+      <Modal.Header>
+        <div className="flex items-center">
+          <ElementTitle noMarignBottom>Name your Account</ElementTitle>
+          <Tooltip content="Account names are stored locally in your browser. If you clear your browser cache they will be lost. We'll be storing them on-chain soon.">
+            <InformationCircleIcon className="h-5 w-5 ml-2 text-th-primary" />
+          </Tooltip>
+        </div>
+      </Modal.Header>
       <div className="pb-2 text-th-fgd-1">Account Name</div>
       <Input
         type="text"
@@ -83,8 +99,8 @@ const AccountNameForm: FunctionComponent<AccountNameFormProps> = ({
       >
         Save Name
       </Button>
-    </>
+    </Modal>
   )
 }
 
-export default AccountNameForm
+export default AccountNameModal

--- a/components/AlertsModal.tsx
+++ b/components/AlertsModal.tsx
@@ -76,7 +76,7 @@ const AlertsModal: FunctionComponent<AlertsModalProps> = ({
     if (isCopied) {
       const timer = setTimeout(() => {
         setIsCopied(false)
-      }, 2000)
+      }, 1500)
       return () => clearTimeout(timer)
     }
   }, [isCopied])

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -18,7 +18,7 @@ const Button: FunctionComponent<ButtonProps> = ({
       onClick={onClick}
       disabled={disabled}
       className={`${className} px-6 py-2 border border-th-fgd-4 bg-th-bkg-2 rounded-md text-th-fgd-1
-      active:border-mango-yellow hover:bg-th-bkg-3 focus:outline-none disabled:bg-th-bkg-2 
+      active:border-th-primary hover:bg-th-bkg-3 focus:outline-none disabled:bg-th-bkg-2 
       disabled:text-th-fgd-4 disabled:cursor-not-allowed`}
       {...props}
     >

--- a/components/MarginBalances.tsx
+++ b/components/MarginBalances.tsx
@@ -6,6 +6,7 @@ import FloatingElement from './FloatingElement'
 import { ElementTitle } from './styles'
 import useMangoStore from '../stores/useMangoStore'
 import useMarketList from '../hooks/useMarketList'
+import useLocalStorageState from '../hooks/useLocalStorageState'
 import {
   abbreviateAddress,
   floorToDecimal,
@@ -33,6 +34,7 @@ export default function MarginBalances() {
   const [showWithdrawModal, setShowWithdrawModal] = useState(false)
   const [showBorrowModal, setShowBorrowModal] = useState(false)
   const [showAccountsModal, setShowAccountsModal] = useState(false)
+  const [accountNames] = useLocalStorageState('accountNames')
 
   const handleCloseDeposit = useCallback(() => {
     setShowDepositModal(false)
@@ -50,13 +52,22 @@ export default function MarginBalances() {
     setShowAccountsModal(false)
   }, [])
 
+  const accountName =
+    accountNames && selectedMarginAccount
+      ? accountNames.find(
+          (acc) => acc.publicKey === selectedMarginAccount.publicKey.toString()
+        )
+      : ''
+
   return (
     <>
       <FloatingElement>
         <div className="flex justify-between pb-5">
           <div className="w-8 h-8" />
           <div className="flex flex-col items-center">
-            <ElementTitle noMarignBottom>Margin Account</ElementTitle>
+            <ElementTitle noMarignBottom>
+              {accountName ? accountName.name : 'Account'}
+            </ElementTitle>
             {selectedMarginAccount ? (
               <Link href={'/account'}>
                 <a className="pt-1 text-th-fgd-3 text-xs underline hover:no-underline">

--- a/components/NewAccount.tsx
+++ b/components/NewAccount.tsx
@@ -1,5 +1,8 @@
 import React, { FunctionComponent, useEffect, useMemo, useState } from 'react'
-import { ExclamationCircleIcon } from '@heroicons/react/outline'
+import {
+  ExclamationCircleIcon,
+  InformationCircleIcon,
+} from '@heroicons/react/outline'
 import {
   nativeToUi,
   sleep,
@@ -21,6 +24,7 @@ import { PublicKey } from '@solana/web3.js'
 import Loading from './Loading'
 import Button from './Button'
 import Slider from './Slider'
+import Tooltip from './Tooltip'
 import { notify } from '../utils/notifications'
 
 interface NewAccountProps {
@@ -185,8 +189,11 @@ const NewAccount: FunctionComponent<NewAccountProps> = ({
       <ElementTitle noMarignBottom>New Account</ElementTitle>
       {showNewAccountName ? (
         <>
-          <div className="text-th-fgd-3 text-center pb-4 pt-2">
+          <div className="flex items-center justify-center text-th-fgd-3 pb-4 pt-2">
             Create a nickname for your account
+            <Tooltip content="Account names are stored locally in your browser. If you clear your browser cache they will be lost. We'll be storing them on-chain soon.">
+              <InformationCircleIcon className="h-5 w-5 ml-2 text-th-primary" />
+            </Tooltip>
           </div>
           <div className="pb-2 text-th-fgd-1">
             Account Name <span className="text-th-fgd-3">(Optional)</span>

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -4,9 +4,10 @@ import {
   ExternalLinkIcon,
   LinkIcon,
   PencilIcon,
+  DuplicateIcon,
 } from '@heroicons/react/outline'
 import useMangoStore from '../stores/useMangoStore'
-import { abbreviateAddress } from '../utils'
+import { abbreviateAddress, copyToClipboard } from '../utils'
 import useMarginInfo from '../hooks/useMarginInfo'
 import PageBodyContainer from '../components/PageBodyContainer'
 import TopBar from '../components/TopBar'
@@ -35,6 +36,7 @@ export default function Account() {
   const [activeTab, setActiveTab] = useState(TABS[0])
   const [showAccountsModal, setShowAccountsModal] = useState(false)
   const [showNameModal, setShowNameModal] = useState(false)
+  const [isCopied, setIsCopied] = useState(false)
   const [accountName, setAccountName] = useState('')
   const accountMarginInfo = useMarginInfo()
   const connected = useMangoStore((s) => s.wallet.connected)
@@ -66,6 +68,20 @@ export default function Account() {
     }
   }, [accountNames, selectedMarginAccount])
 
+  useEffect(() => {
+    if (isCopied) {
+      const timer = setTimeout(() => {
+        setIsCopied(false)
+      }, 1500)
+      return () => clearTimeout(timer)
+    }
+  }, [isCopied])
+
+  const handleCopyPublicKey = (code) => {
+    setIsCopied(true)
+    copyToClipboard(code)
+  }
+
   return (
     <div className={`bg-th-bkg-1 text-th-fgd-1 transition-all`}>
       <TopBar />
@@ -77,8 +93,17 @@ export default function Account() {
                 <h1 className={`font-semibold mr-3 text-th-fgd-1 text-2xl`}>
                   {accountName ? accountName : 'Account'}
                 </h1>
-                <div className="pb-0.5 text-th-fgd-3 ">
+                <div className="flex items-center pb-0.5 text-th-fgd-3 ">
                   {abbreviateAddress(selectedMarginAccount.publicKey)}
+                  <DuplicateIcon
+                    className="cursor-pointer default-transition h-4 w-4 ml-1.5 hover:text-th-fgd-1"
+                    onClick={() =>
+                      handleCopyPublicKey(selectedMarginAccount.publicKey)
+                    }
+                  />
+                  {isCopied ? (
+                    <div className="ml-2 text-th-fgd-2 text-xs">Copied!</div>
+                  ) : null}
                 </div>
               </div>
               <div className="flex items-center">

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -18,7 +18,7 @@ import AccountHistory from '../components/account-page/AccountHistory'
 import AccountsModal from '../components/AccountsModal'
 import EmptyState from '../components/EmptyState'
 import Button from '../components/Button'
-import AccountNameForm from '../components/AccountNameForm'
+import AccountNameModal from '../components/AccountNameModal'
 import Modal from '../components/Modal'
 import { ElementTitle } from '../components/styles'
 import useLocalStorageState from '../hooks/useLocalStorageState'
@@ -86,10 +86,10 @@ export default function Account() {
     <div className={`bg-th-bkg-1 text-th-fgd-1 transition-all`}>
       <TopBar />
       <PageBodyContainer>
-        <div className="flex flex-col sm:flex-row items-end justify-between pt-8 pb-3 sm:pb-6 md:pt-10">
+        <div className="flex flex-col md:flex-row md:items-end justify-between pt-8 pb-3 sm:pb-6 md:pt-10">
           {selectedMarginAccount ? (
             <>
-              <div className="flex items-end">
+              <div className="flex flex-col sm:flex-row sm:items-end pb-4 md:pb-0">
                 <h1 className={`font-semibold mr-3 text-th-fgd-1 text-2xl`}>
                   {accountName ? accountName : 'Account'}
                 </h1>
@@ -108,7 +108,7 @@ export default function Account() {
               </div>
               <div className="flex items-center">
                 <Button
-                  className="text-xs flex items-center justify-center mr-2 pt-0 pb-0 h-8 pl-3 pr-3"
+                  className="text-xs flex flex-grow items-center justify-center mr-2 pt-0 pb-0 h-8 pl-3 pr-3"
                   onClick={() => setShowNameModal(true)}
                 >
                   <div className="flex items-center">
@@ -117,7 +117,7 @@ export default function Account() {
                   </div>
                 </Button>
                 <a
-                  className="border border-th-fgd-4 bg-th-bkg-2 default-transition flex font-bold h-8 items-center justify-center pl-3 pr-3 rounded-md text-th-fgd-1 text-xs hover:bg-th-bkg-3 hover:text-th-fgd-1 focus:outline-none"
+                  className="border border-th-fgd-4 bg-th-bkg-2 default-transition flex flex-grow font-bold h-8 items-center justify-center pl-3 pr-3 rounded-md text-th-fgd-1 text-xs hover:bg-th-bkg-3 hover:text-th-fgd-1 focus:outline-none"
                   href={`https://explorer.solana.com/address/${selectedMarginAccount?.publicKey}`}
                   target="_blank"
                   rel="noopener noreferrer"
@@ -126,7 +126,7 @@ export default function Account() {
                   <ExternalLinkIcon className={`h-4 w-4 ml-1.5`} />
                 </a>
                 <Button
-                  className="text-xs flex items-center justify-center ml-2 pt-0 pb-0 h-8 pl-3 pr-3"
+                  className="text-xs flex flex-grow items-center justify-center ml-2 pt-0 pb-0 h-8 pl-3 pr-3"
                   onClick={() => setShowAccountsModal(true)}
                 >
                   <div className="flex items-center">
@@ -204,15 +204,11 @@ export default function Account() {
         />
       ) : null}
       {showNameModal ? (
-        <Modal onClose={handleCloseNameModal} isOpen={showNameModal}>
-          <Modal.Header>
-            <ElementTitle noMarignBottom>Name your Account</ElementTitle>
-          </Modal.Header>
-          <AccountNameForm
-            accountName={accountName}
-            onClose={handleCloseNameModal}
-          />
-        </Modal>
+        <AccountNameModal
+          accountName={accountName}
+          isOpen={showNameModal}
+          onClose={handleCloseNameModal}
+        />
       ) : null}
     </div>
   )


### PR DESCRIPTION
Let users add a name to their account when they create new accounts and add/edit names from the account page. Names are stored in localStorage in lieu of being ready to store them on-chain.