### PR TITLE
Add account names

### DIFF
--- a/components/AccountNameForm.tsx
+++ b/components/AccountNameForm.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent, useState } from 'react'
 import useMangoStore from '../stores/useMangoStore'
 import useLocalStorageState from '../hooks/useLocalStorageState'
+import { ExclamationCircleIcon } from '@heroicons/react/outline'
 import Input from './Input'
 import Button from './Button'
 
@@ -14,6 +15,7 @@ const AccountNameForm: FunctionComponent<AccountNameFormProps> = ({
   onClose,
 }) => {
   const [name, setName] = useState(accountName || '')
+  const [invalidNameMessage, setInvalidNameMessage] = useState('')
   const selectedMarginAccount = useMangoStore(
     (s) => s.selectedMarginAccount.current
   )
@@ -40,18 +42,40 @@ const AccountNameForm: FunctionComponent<AccountNameFormProps> = ({
     onClose()
   }
 
+  const validateNameInput = () => {
+    if (name.length >= 25) {
+      setInvalidNameMessage('Account name nust be less than 25 characters')
+    }
+    if (name.length === 0) {
+      setInvalidNameMessage('Enter an account name')
+    }
+  }
+
+  const onChangeNameInput = (name) => {
+    setName(name)
+    if (invalidNameMessage) {
+      setInvalidNameMessage('')
+    }
+  }
+
   return (
     <>
       <div className="pb-2 text-th-fgd-1">Account Name</div>
       <Input
         type="text"
         className={`border border-th-fgd-4 flex-grow`}
-        //   error={!!invalidNameMessage}
+        error={!!invalidNameMessage}
         placeholder="e.g. Calypso"
         value={name}
-        //   onBlur={validateNameInput}
-        onChange={(e) => setName(e.target.value)}
+        onBlur={validateNameInput}
+        onChange={(e) => onChangeNameInput(e.target.value)}
       />
+      {invalidNameMessage ? (
+        <div className="flex items-center pt-1.5 text-th-red">
+          <ExclamationCircleIcon className="h-4 w-4 mr-1.5" />
+          {invalidNameMessage}
+        </div>
+      ) : null}
       <Button
         onClick={() => submitName()}
         disabled={null}

--- a/components/AccountNameForm.tsx
+++ b/components/AccountNameForm.tsx
@@ -1,0 +1,66 @@
+import { FunctionComponent, useState } from 'react'
+import useMangoStore from '../stores/useMangoStore'
+import useLocalStorageState from '../hooks/useLocalStorageState'
+import Input from './Input'
+import Button from './Button'
+
+interface AccountNameFormProps {
+  accountName?: string
+  onClose?: (x?) => void
+}
+
+const AccountNameForm: FunctionComponent<AccountNameFormProps> = ({
+  accountName,
+  onClose,
+}) => {
+  const [name, setName] = useState(accountName || '')
+  const selectedMarginAccount = useMangoStore(
+    (s) => s.selectedMarginAccount.current
+  )
+  const [accountNames, setAccountNames] = useLocalStorageState('accountNames')
+
+  const submitName = () => {
+    const nameAccount = {
+      publicKey: selectedMarginAccount.publicKey.toString(),
+      name: name,
+    }
+    if (accountNames) {
+      const hasName = accountNames.find(
+        (acc) => acc.publicKey === selectedMarginAccount.publicKey.toString()
+      )
+      if (!hasName) {
+        accountNames.push(nameAccount)
+      } else {
+        hasName.name = name
+      }
+      setAccountNames(accountNames)
+    } else {
+      setAccountNames([nameAccount])
+    }
+    onClose()
+  }
+
+  return (
+    <>
+      <div className="pb-2 text-th-fgd-1">Account Name</div>
+      <Input
+        type="text"
+        className={`border border-th-fgd-4 flex-grow`}
+        //   error={!!invalidNameMessage}
+        placeholder="e.g. Calypso"
+        value={name}
+        //   onBlur={validateNameInput}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <Button
+        onClick={() => submitName()}
+        disabled={null}
+        className="mt-4 w-full"
+      >
+        Save Name
+      </Button>
+    </>
+  )
+}
+
+export default AccountNameForm

--- a/components/AccountNameModal.tsx
+++ b/components/AccountNameModal.tsx
@@ -60,8 +60,8 @@ const AccountNameModal: FunctionComponent<AccountNameModalProps> = ({
   }
 
   const validateNameInput = () => {
-    if (name.length >= 25) {
-      setInvalidNameMessage('Account name nust be less than 25 characters')
+    if (name.length >= 33) {
+      setInvalidNameMessage('Account name must be 32 characters or less')
     }
     if (name.length === 0) {
       setInvalidNameMessage('Enter an account name')
@@ -80,11 +80,14 @@ const AccountNameModal: FunctionComponent<AccountNameModalProps> = ({
       <Modal.Header>
         <div className="flex items-center">
           <ElementTitle noMarignBottom>Name your Account</ElementTitle>
-          <Tooltip content="Account names are stored on-chain">
-            <InformationCircleIcon className="h-5 w-5 ml-2 text-th-primary" />
-          </Tooltip>
         </div>
       </Modal.Header>
+      <div className="flex items-center justify-center text-th-fgd-3 pb-4">
+        Edit the public nickname for your account
+        <Tooltip content="Account names are stored on-chain">
+          <InformationCircleIcon className="h-5 w-5 ml-2 text-th-primary" />
+        </Tooltip>
+      </div>
       <div className="pb-2 text-th-fgd-1">Account Name</div>
       <Input
         type="text"
@@ -103,7 +106,7 @@ const AccountNameModal: FunctionComponent<AccountNameModalProps> = ({
       ) : null}
       <Button
         onClick={() => submitName()}
-        disabled={null}
+        disabled={name.length >= 33}
         className="mt-4 w-full"
       >
         Save Name

--- a/components/AccountNameModal.tsx
+++ b/components/AccountNameModal.tsx
@@ -1,17 +1,25 @@
 import { FunctionComponent, useState } from 'react'
 import useMangoStore from '../stores/useMangoStore'
 import useLocalStorageState from '../hooks/useLocalStorageState'
-import { ExclamationCircleIcon } from '@heroicons/react/outline'
+import {
+  ExclamationCircleIcon,
+  InformationCircleIcon,
+} from '@heroicons/react/outline'
 import Input from './Input'
 import Button from './Button'
+import Modal from './Modal'
+import { ElementTitle } from './styles'
+import Tooltip from './Tooltip'
 
-interface AccountNameFormProps {
+interface AccountNameModalProps {
   accountName?: string
+  isOpen: boolean
   onClose?: (x?) => void
 }
 
-const AccountNameForm: FunctionComponent<AccountNameFormProps> = ({
+const AccountNameModal: FunctionComponent<AccountNameModalProps> = ({
   accountName,
+  isOpen,
   onClose,
 }) => {
   const [name, setName] = useState(accountName || '')
@@ -59,7 +67,15 @@ const AccountNameForm: FunctionComponent<AccountNameFormProps> = ({
   }
 
   return (
-    <>
+    <Modal onClose={onClose} isOpen={isOpen}>
+      <Modal.Header>
+        <div className="flex items-center">
+          <ElementTitle noMarignBottom>Name your Account</ElementTitle>
+          <Tooltip content="Account names are stored locally in your browser. If you clear your browser cache they will be lost. We'll be storing them on-chain soon.">
+            <InformationCircleIcon className="h-5 w-5 ml-2 text-th-primary" />
+          </Tooltip>
+        </div>
+      </Modal.Header>
       <div className="pb-2 text-th-fgd-1">Account Name</div>
       <Input
         type="text"
@@ -83,8 +99,8 @@ const AccountNameForm: FunctionComponent<AccountNameFormProps> = ({
       >
         Save Name
       </Button>
-    </>
+    </Modal>
   )
 }
 
-export default AccountNameForm
+export default AccountNameModal

--- a/components/AccountsModal.tsx
+++ b/components/AccountsModal.tsx
@@ -1,11 +1,7 @@
 import React, { FunctionComponent, useEffect, useState } from 'react'
 import { RadioGroup } from '@headlessui/react'
 import { CheckCircleIcon } from '@heroicons/react/solid'
-import {
-  ChevronLeftIcon,
-  CurrencyDollarIcon,
-  PlusCircleIcon,
-} from '@heroicons/react/outline'
+import { CurrencyDollarIcon, PlusCircleIcon } from '@heroicons/react/outline'
 import useMangoStore from '../stores/useMangoStore'
 import { MarginAccount } from '@blockworks-foundation/mango-client'
 import { abbreviateAddress } from '../utils'
@@ -14,7 +10,7 @@ import Modal from './Modal'
 import { ElementTitle } from './styles'
 import Button, { LinkButton } from './Button'
 import NewAccount from './NewAccount'
-import { has } from 'immer/dist/internal'
+import { getMarginInfoString } from '../pages/account'
 
 interface AccountsModalProps {
   onClose: () => void
@@ -27,7 +23,6 @@ const AccountsModal: FunctionComponent<AccountsModalProps> = ({
 }) => {
   const [showNewAccountForm, setShowNewAccountForm] = useState(false)
   const [newAccPublicKey, setNewAccPublicKey] = useState(null)
-  const [namedAccounts, setNamedAccounts] = useState([])
   const marginAccounts = useMangoStore((s) => s.marginAccounts)
   const selectedMarginAccount = useMangoStore(
     (s) => s.selectedMarginAccount.current
@@ -37,7 +32,6 @@ const AccountsModal: FunctionComponent<AccountsModalProps> = ({
   const setMangoStore = useMangoStore((s) => s.set)
   const actions = useMangoStore((s) => s.actions)
   const [, setLastAccountViewed] = useLocalStorageState('lastAccountViewed')
-  const [accountNames] = useLocalStorageState('accountNames')
 
   const handleMarginAccountChange = (marginAccount: MarginAccount) => {
     setLastAccountViewed(marginAccount.publicKey.toString())
@@ -57,23 +51,6 @@ const AccountsModal: FunctionComponent<AccountsModalProps> = ({
       })
     }
   }, [marginAccounts, newAccPublicKey])
-
-  useEffect(() => {
-    if (accountNames && marginAccounts) {
-      const namedAccounts = []
-      for (let i = 0; marginAccounts.length > i; i++) {
-        const hasName = accountNames.find(
-          (acc) => acc.publicKey === marginAccounts[i].publicKey.toString()
-        )
-        if (hasName) {
-          namedAccounts.push({ ...marginAccounts[i], name: hasName.name })
-        } else {
-          namedAccounts.push({ ...marginAccounts[i], name: '' })
-        }
-      }
-      setNamedAccounts(namedAccounts)
-    }
-  }, [accountNames, marginAccounts])
 
   const handleNewAccountCreation = (newAccPublicKey) => {
     if (newAccPublicKey) {
@@ -170,8 +147,8 @@ const AccountsModal: FunctionComponent<AccountsModalProps> = ({
                                 <CurrencyDollarIcon className="h-5 w-5 mr-2.5" />
                                 <div>
                                   <div className="pb-0.5">
-                                    {namedAccounts[i] && namedAccounts[i].name
-                                      ? namedAccounts[i].name
+                                    {marginAccounts[i] && marginAccounts[i].info
+                                      ? getMarginInfoString(marginAccounts[i])
                                       : abbreviateAddress(account.publicKey)}
                                   </div>
                                   {prices && selectedMangoGroup ? (

--- a/components/AlertsModal.tsx
+++ b/components/AlertsModal.tsx
@@ -76,7 +76,7 @@ const AlertsModal: FunctionComponent<AlertsModalProps> = ({
     if (isCopied) {
       const timer = setTimeout(() => {
         setIsCopied(false)
-      }, 2000)
+      }, 1500)
       return () => clearTimeout(timer)
     }
   }, [isCopied])

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -18,7 +18,7 @@ const Button: FunctionComponent<ButtonProps> = ({
       onClick={onClick}
       disabled={disabled}
       className={`${className} px-6 py-2 border border-th-fgd-4 bg-th-bkg-2 rounded-md text-th-fgd-1
-      active:border-mango-yellow hover:bg-th-bkg-3 focus:outline-none disabled:bg-th-bkg-2 
+      active:border-th-primary hover:bg-th-bkg-3 focus:outline-none disabled:bg-th-bkg-2 
       disabled:text-th-fgd-4 disabled:cursor-not-allowed`}
       {...props}
     >

--- a/components/DepositModal.tsx
+++ b/components/DepositModal.tsx
@@ -186,7 +186,8 @@ const DepositModal: FunctionComponent<DepositModalProps> = ({
         wallet,
         selectedAccount.account.mint,
         selectedAccount.publicKey,
-        Number(inputAmount)
+        Number(inputAmount),
+        'Account'
       )
         .then(async (_response: Array<any>) => {
           await sleep(1000)

--- a/components/MarginBalances.tsx
+++ b/components/MarginBalances.tsx
@@ -6,7 +6,6 @@ import FloatingElement from './FloatingElement'
 import { ElementTitle } from './styles'
 import useMangoStore from '../stores/useMangoStore'
 import useMarketList from '../hooks/useMarketList'
-import useLocalStorageState from '../hooks/useLocalStorageState'
 import {
   abbreviateAddress,
   floorToDecimal,
@@ -34,7 +33,6 @@ export default function MarginBalances() {
   const [showWithdrawModal, setShowWithdrawModal] = useState(false)
   const [showBorrowModal, setShowBorrowModal] = useState(false)
   const [showAccountsModal, setShowAccountsModal] = useState(false)
-  const [accountNames] = useLocalStorageState('accountNames')
 
   const handleCloseDeposit = useCallback(() => {
     setShowDepositModal(false)
@@ -51,13 +49,6 @@ export default function MarginBalances() {
   const handleCloseAccounts = useCallback(() => {
     setShowAccountsModal(false)
   }, [])
-
-  const accountName =
-    accountNames && selectedMarginAccount
-      ? accountNames.find(
-          (acc) => acc.publicKey === selectedMarginAccount.publicKey.toString()
-        )
-      : ''
 
   return (
     <>

--- a/components/MarginBalances.tsx
+++ b/components/MarginBalances.tsx
@@ -6,6 +6,7 @@ import FloatingElement from './FloatingElement'
 import { ElementTitle } from './styles'
 import useMangoStore from '../stores/useMangoStore'
 import useMarketList from '../hooks/useMarketList'
+import useLocalStorageState from '../hooks/useLocalStorageState'
 import {
   abbreviateAddress,
   floorToDecimal,
@@ -33,6 +34,7 @@ export default function MarginBalances() {
   const [showWithdrawModal, setShowWithdrawModal] = useState(false)
   const [showBorrowModal, setShowBorrowModal] = useState(false)
   const [showAccountsModal, setShowAccountsModal] = useState(false)
+  const [accountNames] = useLocalStorageState('accountNames')
 
   const handleCloseDeposit = useCallback(() => {
     setShowDepositModal(false)
@@ -50,13 +52,22 @@ export default function MarginBalances() {
     setShowAccountsModal(false)
   }, [])
 
+  const accountName =
+    accountNames && selectedMarginAccount
+      ? accountNames.find(
+          (acc) => acc.publicKey === selectedMarginAccount.publicKey.toString()
+        )
+      : ''
+
   return (
     <>
       <FloatingElement>
         <div className="flex justify-between pb-5">
           <div className="w-8 h-8" />
           <div className="flex flex-col items-center">
-            <ElementTitle noMarignBottom>Margin Account</ElementTitle>
+            <ElementTitle noMarignBottom>
+              {accountName ? accountName.name : 'Account'}
+            </ElementTitle>
             {selectedMarginAccount ? (
               <Link href={'/account'}>
                 <a className="pt-1 text-th-fgd-3 text-xs underline hover:no-underline">

--- a/components/MarginBalances.tsx
+++ b/components/MarginBalances.tsx
@@ -17,6 +17,7 @@ import BorrowModal from './BorrowModal'
 import Button from './Button'
 import Tooltip from './Tooltip'
 import AccountsModal from './AccountsModal'
+import { getMarginInfoString } from '../pages/account'
 
 export default function MarginBalances() {
   const selectedMangoGroup = useMangoStore((s) => s.selectedMangoGroup.current)
@@ -57,7 +58,7 @@ export default function MarginBalances() {
           <div className="w-8 h-8" />
           <div className="flex flex-col items-center">
             <ElementTitle noMarignBottom>
-              {accountName ? accountName.name : 'Account'}
+              {getMarginInfoString(selectedMarginAccount)}
             </ElementTitle>
             {selectedMarginAccount ? (
               <Link href={'/account'}>

--- a/components/NewAccount.tsx
+++ b/components/NewAccount.tsx
@@ -178,8 +178,8 @@ const NewAccount: FunctionComponent<NewAccountProps> = ({
       {showNewAccountName ? (
         <>
           <div className="flex items-center justify-center text-th-fgd-3 pb-4 pt-2">
-            Create a nickname for your account
-            <Tooltip content="Account names are stored publicly on-chain.">
+            Create a public nickname for your account
+            <Tooltip content="Account names are stored on-chain">
               <InformationCircleIcon className="h-5 w-5 ml-2 text-th-primary" />
             </Tooltip>
           </div>

--- a/components/NewAccount.tsx
+++ b/components/NewAccount.tsx
@@ -1,5 +1,8 @@
 import React, { FunctionComponent, useEffect, useMemo, useState } from 'react'
-import { ExclamationCircleIcon } from '@heroicons/react/outline'
+import {
+  ExclamationCircleIcon,
+  InformationCircleIcon,
+} from '@heroicons/react/outline'
 import {
   nativeToUi,
   sleep,
@@ -21,6 +24,7 @@ import { PublicKey } from '@solana/web3.js'
 import Loading from './Loading'
 import Button from './Button'
 import Slider from './Slider'
+import Tooltip from './Tooltip'
 import { notify } from '../utils/notifications'
 
 interface NewAccountProps {
@@ -185,8 +189,11 @@ const NewAccount: FunctionComponent<NewAccountProps> = ({
       <ElementTitle noMarignBottom>New Account</ElementTitle>
       {showNewAccountName ? (
         <>
-          <div className="text-th-fgd-3 text-center pb-4 pt-2">
+          <div className="flex items-center justify-center text-th-fgd-3 pb-4 pt-2">
             Create a nickname for your account
+            <Tooltip content="Account names are stored locally in your browser. If you clear your browser cache they will be lost. We'll be storing them on-chain soon.">
+              <InformationCircleIcon className="h-5 w-5 ml-2 text-th-primary" />
+            </Tooltip>
           </div>
           <div className="pb-2 text-th-fgd-1">
             Account Name <span className="text-th-fgd-3">(Optional)</span>

--- a/components/NewAccount.tsx
+++ b/components/NewAccount.tsx
@@ -97,7 +97,8 @@ const NewAccount: FunctionComponent<NewAccountProps> = ({
       wallet,
       selectedAccount.account.mint,
       selectedAccount.publicKey,
-      Number(inputAmount)
+      Number(inputAmount),
+      name
     )
       .then(async (_response: Array<any>) => {
         await sleep(1000)
@@ -150,8 +151,8 @@ const NewAccount: FunctionComponent<NewAccountProps> = ({
   }
 
   const validateNameInput = () => {
-    if (name.length >= 25) {
-      setInvalidNameMessage('Account name nust be less than 25 characters')
+    if (name.length >= 33) {
+      setInvalidNameMessage('Account name must be 32 characters or less')
     }
     if (name.length === 0) {
       setInvalidNameMessage('Enter an account name')
@@ -195,8 +196,15 @@ const NewAccount: FunctionComponent<NewAccountProps> = ({
             onBlur={validateNameInput}
             onChange={(e) => onChangeNameInput(e.target.value)}
           />
+          {invalidNameMessage ? (
+            <div className="flex items-center pt-1.5 text-th-red">
+              <ExclamationCircleIcon className="h-4 w-4 mr-1.5" />
+              {invalidNameMessage}
+            </div>
+          ) : null}
           <Button
             onClick={() => setShowNewAccountName(false)}
+            disabled={name.length >= 33}
             className="mt-4 w-full"
           >
             Next

--- a/components/NewAccount.tsx
+++ b/components/NewAccount.tsx
@@ -12,7 +12,6 @@ import AccountSelect from './AccountSelect'
 import { ElementTitle } from './styles'
 import useMangoStore from '../stores/useMangoStore'
 import useMarketList from '../hooks/useMarketList'
-import useLocalStorageState from '../hooks/useLocalStorageState'
 import {
   getSymbolForTokenMintAddress,
   DECIMALS,
@@ -55,7 +54,6 @@ const NewAccount: FunctionComponent<NewAccountProps> = ({
     [symbols, walletAccounts]
   )
   const [selectedAccount, setSelectedAccount] = useState(depositAccounts[0])
-  const [accountNames, setAccountNames] = useLocalStorageState('accountNames')
 
   const symbol = getSymbolForTokenMintAddress(
     selectedAccount?.account?.mint.toString()
@@ -106,16 +104,6 @@ const NewAccount: FunctionComponent<NewAccountProps> = ({
         actions.fetchWalletBalances()
         actions.fetchMarginAccounts()
         setSubmitting(false)
-        if (name) {
-          accountNames
-            ? setAccountNames([
-                ...accountNames,
-                { publicKey: _response[0].publicKey.toString(), name: name },
-              ])
-            : setAccountNames([
-                { publicKey: _response[0].publicKey.toString(), name: name },
-              ])
-        }
         onAccountCreation(_response[0].publicKey)
       })
       .catch((err) => {
@@ -191,7 +179,7 @@ const NewAccount: FunctionComponent<NewAccountProps> = ({
         <>
           <div className="flex items-center justify-center text-th-fgd-3 pb-4 pt-2">
             Create a nickname for your account
-            <Tooltip content="Account names are stored locally in your browser. If you clear your browser cache they will be lost. We'll be storing them on-chain soon.">
+            <Tooltip content="Account names are stored publicly on-chain.">
               <InformationCircleIcon className="h-5 w-5 ml-2 text-th-primary" />
             </Tooltip>
           </div>

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     }
   },
   "dependencies": {
-    "@blockworks-foundation/mango-client": "2.1.0",
+    "@blockworks-foundation/mango-client": "2.1.3",
     "@emotion/react": "^11.1.5",
     "@emotion/styled": "^11.1.5",
     "@headlessui/react": "^1.2.0",

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -4,9 +4,10 @@ import {
   ExternalLinkIcon,
   LinkIcon,
   PencilIcon,
+  DuplicateIcon,
 } from '@heroicons/react/outline'
 import useMangoStore from '../stores/useMangoStore'
-import { abbreviateAddress } from '../utils'
+import { abbreviateAddress, copyToClipboard } from '../utils'
 import useMarginInfo from '../hooks/useMarginInfo'
 import PageBodyContainer from '../components/PageBodyContainer'
 import TopBar from '../components/TopBar'
@@ -35,6 +36,7 @@ export default function Account() {
   const [activeTab, setActiveTab] = useState(TABS[0])
   const [showAccountsModal, setShowAccountsModal] = useState(false)
   const [showNameModal, setShowNameModal] = useState(false)
+  const [isCopied, setIsCopied] = useState(false)
   const [accountName, setAccountName] = useState('')
   const accountMarginInfo = useMarginInfo()
   const connected = useMangoStore((s) => s.wallet.connected)
@@ -66,6 +68,20 @@ export default function Account() {
     }
   }, [accountNames, selectedMarginAccount])
 
+  useEffect(() => {
+    if (isCopied) {
+      const timer = setTimeout(() => {
+        setIsCopied(false)
+      }, 1500)
+      return () => clearTimeout(timer)
+    }
+  }, [isCopied])
+
+  const handleCopyPublicKey = (code) => {
+    setIsCopied(true)
+    copyToClipboard(code)
+  }
+
   return (
     <div className={`bg-th-bkg-1 text-th-fgd-1 transition-all`}>
       <TopBar />
@@ -77,8 +93,17 @@ export default function Account() {
                 <h1 className={`font-semibold mr-3 text-th-fgd-1 text-2xl`}>
                   {accountName ? accountName : 'Account'}
                 </h1>
-                <div className="pb-0.5 text-th-fgd-3 ">
+                <div className="flex items-center pb-0.5 text-th-fgd-3 ">
                   {abbreviateAddress(selectedMarginAccount.publicKey)}
+                  <DuplicateIcon
+                    className="cursor-pointer default-transition h-4 w-4 ml-1.5 hover:text-th-fgd-1"
+                    onClick={() =>
+                      handleCopyPublicKey(selectedMarginAccount.publicKey)
+                    }
+                  />
+                  {isCopied ? (
+                    <div className="ml-2 text-th-fgd-2 text-xs">Copied!</div>
+                  ) : null}
                 </div>
               </div>
               <div className="flex items-center">

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -18,7 +18,7 @@ import AccountHistory from '../components/account-page/AccountHistory'
 import AccountsModal from '../components/AccountsModal'
 import EmptyState from '../components/EmptyState'
 import Button from '../components/Button'
-import AccountNameForm from '../components/AccountNameForm'
+import AccountNameModal from '../components/AccountNameModal'
 import Modal from '../components/Modal'
 import { ElementTitle } from '../components/styles'
 import useLocalStorageState from '../hooks/useLocalStorageState'
@@ -86,10 +86,10 @@ export default function Account() {
     <div className={`bg-th-bkg-1 text-th-fgd-1 transition-all`}>
       <TopBar />
       <PageBodyContainer>
-        <div className="flex flex-col sm:flex-row items-end justify-between pt-8 pb-3 sm:pb-6 md:pt-10">
+        <div className="flex flex-col md:flex-row md:items-end justify-between pt-8 pb-3 sm:pb-6 md:pt-10">
           {selectedMarginAccount ? (
             <>
-              <div className="flex items-end">
+              <div className="flex flex-col sm:flex-row sm:items-end pb-4 md:pb-0">
                 <h1 className={`font-semibold mr-3 text-th-fgd-1 text-2xl`}>
                   {accountName ? accountName : 'Account'}
                 </h1>
@@ -108,7 +108,7 @@ export default function Account() {
               </div>
               <div className="flex items-center">
                 <Button
-                  className="text-xs flex items-center justify-center mr-2 pt-0 pb-0 h-8 pl-3 pr-3"
+                  className="text-xs flex flex-grow items-center justify-center mr-2 pt-0 pb-0 h-8 pl-3 pr-3"
                   onClick={() => setShowNameModal(true)}
                 >
                   <div className="flex items-center">
@@ -117,7 +117,7 @@ export default function Account() {
                   </div>
                 </Button>
                 <a
-                  className="border border-th-fgd-4 bg-th-bkg-2 default-transition flex font-bold h-8 items-center justify-center pl-3 pr-3 rounded-md text-th-fgd-1 text-xs hover:bg-th-bkg-3 hover:text-th-fgd-1 focus:outline-none"
+                  className="border border-th-fgd-4 bg-th-bkg-2 default-transition flex flex-grow font-bold h-8 items-center justify-center pl-3 pr-3 rounded-md text-th-fgd-1 text-xs hover:bg-th-bkg-3 hover:text-th-fgd-1 focus:outline-none"
                   href={`https://explorer.solana.com/address/${selectedMarginAccount?.publicKey}`}
                   target="_blank"
                   rel="noopener noreferrer"
@@ -126,7 +126,7 @@ export default function Account() {
                   <ExternalLinkIcon className={`h-4 w-4 ml-1.5`} />
                 </a>
                 <Button
-                  className="text-xs flex items-center justify-center ml-2 pt-0 pb-0 h-8 pl-3 pr-3"
+                  className="text-xs flex flex-grow items-center justify-center ml-2 pt-0 pb-0 h-8 pl-3 pr-3"
                   onClick={() => setShowAccountsModal(true)}
                 >
                   <div className="flex items-center">
@@ -204,15 +204,11 @@ export default function Account() {
         />
       ) : null}
       {showNameModal ? (
-        <Modal onClose={handleCloseNameModal} isOpen={showNameModal}>
-          <Modal.Header>
-            <ElementTitle noMarignBottom>Name your Account</ElementTitle>
-          </Modal.Header>
-          <AccountNameForm
-            accountName={accountName}
-            onClose={handleCloseNameModal}
-          />
-        </Modal>
+        <AccountNameModal
+          accountName={accountName}
+          isOpen={showNameModal}
+          onClose={handleCloseNameModal}
+        />
       ) : null}
     </div>
   )

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -19,9 +19,7 @@ import AccountsModal from '../components/AccountsModal'
 import EmptyState from '../components/EmptyState'
 import Button from '../components/Button'
 import AccountNameModal from '../components/AccountNameModal'
-import Modal from '../components/Modal'
-import { ElementTitle } from '../components/styles'
-import useLocalStorageState from '../hooks/useLocalStorageState'
+import { MarginAccount } from '@blockworks-foundation/mango-client'
 
 const TABS = [
   'Assets',
@@ -32,18 +30,27 @@ const TABS = [
   'History',
 ]
 
+export function getMarginInfoString(marginAccount: MarginAccount) {
+  return marginAccount?.info
+    ? String.fromCharCode(...marginAccount?.info).replaceAll(
+        String.fromCharCode(0),
+        ''
+      )
+    : ''
+}
+
 export default function Account() {
   const [activeTab, setActiveTab] = useState(TABS[0])
   const [showAccountsModal, setShowAccountsModal] = useState(false)
   const [showNameModal, setShowNameModal] = useState(false)
   const [isCopied, setIsCopied] = useState(false)
-  const [accountName, setAccountName] = useState('')
   const accountMarginInfo = useMarginInfo()
   const connected = useMangoStore((s) => s.wallet.connected)
   const selectedMarginAccount = useMangoStore(
     (s) => s.selectedMarginAccount.current
   )
-  const [accountNames] = useLocalStorageState('accountNames')
+  const marginInfoString = getMarginInfoString(selectedMarginAccount)
+  const [accountName, setAccountName] = useState(marginInfoString)
 
   const handleTabChange = (tabName) => {
     setActiveTab(tabName)
@@ -56,17 +63,13 @@ export default function Account() {
   }, [])
 
   useEffect(() => {
-    if (accountNames && selectedMarginAccount) {
-      const hasName = accountNames.find(
-        (acc) => acc.publicKey === selectedMarginAccount.publicKey.toString()
-      )
-      if (hasName) {
-        setAccountName(hasName.name)
-      } else {
-        setAccountName('')
-      }
+    if (selectedMarginAccount) {
+      const marginInfoString = getMarginInfoString(selectedMarginAccount)
+      setAccountName(marginInfoString)
+    } else {
+      setAccountName('')
     }
-  }, [accountNames, selectedMarginAccount])
+  }, [selectedMarginAccount])
 
   useEffect(() => {
     if (isCopied) {

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -36,7 +36,7 @@ export function getMarginInfoString(marginAccount: MarginAccount) {
         String.fromCharCode(0),
         ''
       )
-    : ''
+    : 'Account'
 }
 
 export default function Account() {

--- a/utils/mango.tsx
+++ b/utils/mango.tsx
@@ -29,6 +29,7 @@ import {
   NUM_TOKENS,
 } from '@blockworks-foundation/mango-client/lib/layout'
 import {
+  makeAddMarginAccountInfoInstruction,
   makeBorrowInstruction,
   makeSettleBorrowInstruction,
   makeSettleFundsInstruction,
@@ -1512,5 +1513,32 @@ export async function settleAllTrades(
     wallet,
     [],
     'Settle All Trades'
+  )
+}
+
+export async function addMarginAccountInfo(
+  connection: Connection,
+  programId: PublicKey,
+  mangoGroup: MangoGroup,
+  marginAccount: MarginAccount,
+  wallet: Wallet,
+  info: string
+) {
+  const transaction = new Transaction()
+  const instruction = makeAddMarginAccountInfoInstruction(
+    programId,
+    mangoGroup.publicKey,
+    marginAccount.publicKey,
+    wallet.publicKey,
+    info
+  )
+  transaction.add(instruction)
+
+  return await packageAndSend(
+    transaction,
+    connection,
+    wallet,
+    [],
+    'Add MarginAccount Info'
   )
 }

--- a/utils/mango.tsx
+++ b/utils/mango.tsx
@@ -232,7 +232,8 @@ export async function initMarginAccountAndDeposit(
   wallet: Wallet,
   token: PublicKey,
   tokenAcc: PublicKey,
-  quantity: number
+  quantity: number,
+  accountName: string
 ): Promise<Array<any>> {
   const transaction = new Transaction()
   const signers = []
@@ -284,9 +285,18 @@ export async function initMarginAccountAndDeposit(
     programId,
   })
 
+  const setNameInstruction = makeAddMarginAccountInfoInstruction(
+    programId,
+    mangoGroup.publicKey,
+    accInstr.account.publicKey,
+    wallet.publicKey,
+    accountName
+  )
+
   // Add all instructions to one atomic transaction
   transaction.add(accInstr.instruction)
   transaction.add(initMarginAccountInstruction)
+  transaction.add(setNameInstruction)
 
   const tokenIndex = mangoGroup.getTokenIndex(token)
   const nativeQuantity = uiToNative(

--- a/yarn.lock
+++ b/yarn.lock
@@ -993,10 +993,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@blockworks-foundation/mango-client@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@blockworks-foundation/mango-client/-/mango-client-2.1.0.tgz#321b4a36c269f8da05bda01fe90b7f62b1919914"
-  integrity sha512-KhQ7UGID7lVClnRv2vBtXlcWCkgU6v8/y2vZNICvC0tJyroMHFL/c3rXOhnVtrk9tv/szHcX3RZ3OrYjli6bjA==
+"@blockworks-foundation/mango-client@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@blockworks-foundation/mango-client/-/mango-client-2.1.3.tgz#6153c0ac53e2cd7f4c729fb3eea9ef5de1480ba2"
+  integrity sha512-oD7wl7DUq2E4rSTMxZ/uiS6ZixF9CDh8Z4RSiStcmCe0Lc98gACtJAsloRLieyqTD6369r0ivlLsjk/FDy69SA==
   dependencies:
     "@project-serum/common" "^0.0.1-beta.3"
     "@project-serum/serum" "^0.13.20"
@@ -2522,9 +2522,9 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-"borsh@https://github.com/defactojob/borsh-js#field-mapper":
+"borsh@git+https://github.com/defactojob/borsh-js.git#field-mapper":
   version "0.3.1"
-  resolved "https://github.com/defactojob/borsh-js#33a0d24af281112c0a48efb3fa503f3212443de9"
+  resolved "git+https://github.com/defactojob/borsh-js.git#33a0d24af281112c0a48efb3fa503f3212443de9"
   dependencies:
     "@types/bn.js" "^4.11.5"
     bn.js "^5.0.0"


### PR DESCRIPTION
Let users add a name to their account when they create new accounts and add/edit names from the account page. Names are stored in a 32 byte string on chain, https://github.com/blockworks-foundation/mango/commit/e4fe8e7084d37563e1f58b4c99003d99ef3f625b