### PR TITLE
Updates from feedback

### DIFF
--- a/pages/liquidation-calculator.tsx
+++ b/pages/liquidation-calculator.tsx
@@ -1,7 +1,6 @@
 import { RefreshIcon } from '@heroicons/react/outline'
 import { Table, Thead, Tbody, Tr, Th, Td } from 'react-super-responsive-table'
 import useMangoStore from '../stores/useMangoStore'
-import { useBalances } from '../hooks/useBalances'
 import useMarketList from '../hooks/useMarketList'
 import PageBodyContainer from '../components/PageBodyContainer'
 import TopBar from '../components/TopBar'
@@ -10,220 +9,250 @@ import Input from '../components/Input'
 import Slider from '../components/Slider'
 import { useState, useEffect } from 'react'
 import Tooltip from '../components/Tooltip'
+import { floorToDecimal, ceilToDecimal, tokenPrecision } from '../utils/index'
+
+interface AssetBar {
+  price: number
+  assetName: string
+  deposit: number
+  borrow: number
+  net: number
+  precision: number
+  priceDisabled: boolean
+}
+
+interface ScenarioDetailCalculator {
+  rowData: AssetBar[]
+}
 
 export default function LiquidationCalculator() {
-  const balances = useBalances()
   const prices = useMangoStore((s) => s.selectedMangoGroup.prices)
   const { symbols } = useMarketList()
   const connected = useMangoStore((s) => s.wallet.connected)
+  const selectedMangoGroup = useMangoStore((s) => s.selectedMangoGroup.current)
+  const selectedMarginAccount = useMangoStore(
+    (s) => s.selectedMarginAccount.current
+  )
 
-  const [depositValues, setDepositValues] = useState([])
-  const [borrowValues, setBorrowValues] = useState([])
-  const [priceValues, setPriceValues] = useState([])
-  const [depositsInitialized, setDepositsInitialized] = useState(false)
-  const [borrowsInitialized, setBorrowsInitialized] = useState(false)
-  const [pricesInitialized, setPricesInitialized] = useState(false)
-  const [sliderPercentage, setSliderPercentage] = useState(0)
   const [loading, setLoading] = useState(true)
+  const [assetBars, setAssetBars] = useState<ScenarioDetailCalculator>()
+  const [sliderPercentage, setSliderPercentage] = useState(0)
 
   useEffect(() => {
     if (connected) {
-      InitializeDeposits()
-      InitializeBorrows()
-      InitializePrices()
-      setLoading(false)
-    } else {
-      setLoading(true)
-      setSliderPercentage(50)
-    }
-  }, [connected])
-
-  // Initialise states
-  function InitializeDeposits() {
-    let newDepositValues
-
-    {
-      prices.length > 0 && balances
-        ? (newDepositValues = balances.map((balance) => {
-            return balance.marginDeposits
-          }))
-        : null
-    }
-    setDepositValues(newDepositValues)
-    setDepositsInitialized(true)
-  }
-
-  function InitializeBorrows() {
-    let newBorrowsValues
-    {
-      prices.length > 0 && balances
-        ? (newBorrowsValues = balances.map((balance) => {
-            return balance.borrows
-          }))
-        : null
-    }
-    setBorrowValues(newBorrowsValues)
-    setBorrowsInitialized(true)
-  }
-
-  function InitializePrices() {
-    let newPricesValues
-    {
-      prices.length > 0 && balances
-        ? (newPricesValues = prices.map((val) => {
-            return val
-          }))
-        : null
-    }
-    setPriceValues(newPricesValues)
-    setPricesInitialized(true)
-  }
-
-  // Set states
-  function setDeposit(value, index) {
-    const newDepositValues = depositValues.map((val, i) => {
-      return i === index ? value : val
-    })
-    setDepositValues(newDepositValues)
-  }
-
-  function setBorrow(value, index) {
-    const newBorrowValues = borrowValues.map((val, i) => {
-      return i === index ? value : val
-    })
-    setBorrowValues(newBorrowValues)
-  }
-
-  function setPrice(value, index) {
-    const newPricesValues = priceValues.map((val, i) => {
-      return i === index ? value : val
-    })
-    setPriceValues(newPricesValues)
-  }
-
-  // Get states
-  function getDeposit(index) {
-    let deposit
-    {
-      depositsInitialized
-        ? (deposit = depositValues[index])
-        : InitializeDeposits()
-      deposit = depositValues[index]
-    }
-    return deposit
-  }
-
-  function getBorrow(index) {
-    let borrow
-    {
-      borrowsInitialized ? (borrow = borrowValues[index]) : InitializeBorrows()
-      borrow = borrowValues[index]
-    }
-    return borrow
-  }
-
-  function getPrice(index) {
-    let price
-    {
-      pricesInitialized ? (price = priceValues[index]) : InitializePrices()
-      if (index === 4) {
-        price = priceValues[index]
-      } else {
-        price = (priceValues[index] * sliderPercentage * 2) / 100
+      if (loading) {
+        setSliderPercentage(50)
+        initilizeScenario()
+        setLoading(false)
       }
+    } else {
+      setSliderPercentage(50)
+      setLoading(true)
     }
-    return price
-  }
+  }, [connected, loading])
 
-  // Ancilliary functions
-  function getCollateralWeight(index) {
-    let collWeight
-    collWeight =
-      depositValues[index] * priceValues[index] -
-      borrowValues[index] * priceValues[index]
-    if (collWeight > 0) {
-      collWeight = collWeight * ((sliderPercentage * 2) / 100)
-    }
-    return collWeight.toFixed(2)
-  }
-
-  function getScenarioEquity(dV, bV) {
-    let equity
-    dV && bV
-      ? (equity = getScenarioAssets(dV) - getScenarioLiability(bV))
-      : (equity = 0)
-    if(equity < 0) {
-      equity = 0
-    }
-    return equity.toFixed(2)
-  }
-
-  function getScenarioAssets(dV) {
-    let assets
-    depositValues
-      ? (assets = dV.reduce(
-          (a, v, i) =>
-            (a = a + v * ((priceValues[i] * sliderPercentage * 2) / 100)),
-          0
-        ))
-      : (assets = 0)
-    return assets.toFixed(2)
-  }
-
-  function getScenarioLiability(bV) {
-    let liabilities
-    borrowValues
-      ? (liabilities = bV.reduce((a, v, i) => (a = a + v * priceValues[i]), 0))
-      : (liabilities = 0)
-    return liabilities.toFixed(2)
-  }
-
-  function getScenarioLeverage(dV, bV) {
-    let leverage
-    dV && bV
-      ? (leverage = getScenarioLiability(bV) / getScenarioEquity(dV, bV))
-      : (leverage = 0)
-    if (leverage < 0 || leverage > 999) {
-      leverage = 0
-    }
-    return leverage.toFixed(2)
-  }
-
-  function getScenarioCollateralRatio(dV, bV) {
-    let collateralRatio
-    dV && bV
-      ? (collateralRatio =
-          (getScenarioAssets(dV) / getScenarioLiability(bV)) * 100)
-      : (collateralRatio = 0)
-
-    if (collateralRatio > 999) {
-      collateralRatio = 999
-    }
-    return collateralRatio.toFixed(0)
-  }
-
-  function getLiquidationMovePercent(dV, bV) {
-    let percentMove
-    dV && bV
-      ? (percentMove =
-          (1 - 100 / (getScenarioCollateralRatio(dV, bV) / 1.1)) * 100)
-      : (percentMove = 0)
-    if (percentMove <= 0) {
-      return 'Account Liquidated'
-    }
-    return percentMove.toFixed(0) + '%'
-  }
-
-  function resetAll() {
+  const initilizeScenario = () => {
     setSliderPercentage(50)
-    setDepositsInitialized(false)
-    setBorrowsInitialized(false)
-    setPricesInitialized(false)
+    const assetBarData = Object.entries(symbols).map(([assetName], i) => {
+      return {
+        price: prices[i],
+        assetName: assetName,
+        deposit: selectedMarginAccount
+          ? floorToDecimal(
+              selectedMarginAccount.getUiDeposit(selectedMangoGroup, i),
+              tokenPrecision[assetName]
+            )
+          : 0,
+        borrow: selectedMarginAccount
+          ? ceilToDecimal(
+              selectedMarginAccount.getUiBorrow(selectedMangoGroup, i),
+              tokenPrecision[assetName]
+            )
+          : 0,
+        net: selectedMarginAccount
+          ? (floorToDecimal(
+              selectedMarginAccount.getUiDeposit(selectedMangoGroup, i),
+              tokenPrecision[assetName]
+            ) -
+              ceilToDecimal(
+                selectedMarginAccount.getUiBorrow(selectedMangoGroup, i),
+                tokenPrecision[assetName]
+              )) *
+            prices[i]
+          : 0,
+        precision: tokenPrecision[assetName],
+        priceDisabled: assetName === 'USDC' ? true : false,
+      }
+    })
+
+    const initScenarioData = updateScenario(assetBarData)
+    setAssetBars(initScenarioData)
+  }
+
+  const updateScenario = (rowData: AssetBar[]) => {
+    return {
+      rowData: rowData,
+    } as ScenarioDetailCalculator
+  }
+
+  const updateScenarioValue = (assetName, field, val) => {
+    const updatedRowData = assetBars.rowData.map((asset) => {
+      if (asset.assetName == assetName) {
+        let updatedNet: number
+        switch (field) {
+          case 'deposit':
+            updatedNet = (val - asset.borrow) * asset.price
+            break
+          case 'borrow':
+            updatedNet = (asset.deposit - val) * asset.price
+            break
+          case 'price':
+            updatedNet = (asset.deposit - asset.borrow) * val
+            break
+        }
+        return { ...asset, [field]: val, net: updatedNet }
+      } else {
+        return asset
+      }
+    })
+    const updatedScenarioData = updateScenario(updatedRowData)
+    setAssetBars(updatedScenarioData)
+  }
+
+  const resetScenarioColumn = (column) => {
+    const resetRowData = assetBars.rowData.map((asset, i) => {
+      let resetValue: number
+      let resetNet: number
+      switch (column) {
+        case 'deposit':
+          resetValue = selectedMarginAccount
+            ? floorToDecimal(
+                selectedMarginAccount.getUiDeposit(selectedMangoGroup, i),
+                tokenPrecision[asset.assetName]
+              )
+            : 0
+          resetNet = (resetValue - asset.borrow) * prices[i]
+          break
+        case 'borrow':
+          resetValue = selectedMarginAccount
+            ? ceilToDecimal(
+                selectedMarginAccount.getUiBorrow(selectedMangoGroup, i),
+                tokenPrecision[asset.assetName]
+              )
+            : 0
+          resetNet = (asset.deposit - resetValue) * prices[i]
+          break
+        case 'price':
+          setSliderPercentage(50)
+          resetValue = prices[i]
+          resetNet = (asset.deposit - asset.borrow) * prices[i]
+          break
+      }
+
+      return { ...asset, [column]: resetValue, net: resetNet }
+    })
+    const updatedScenarioData = updateScenario(resetRowData)
+    setAssetBars(updatedScenarioData)
   }
 
   const onChangeSlider = async (percentage) => {
     setSliderPercentage(percentage)
   }
+
+  function getScenarioDetails() {
+    if (connected && assetBars && !loading) {
+      const scenarioHashMap = new Map()
+      scenarioHashMap.set(
+        'liabilities',
+        ceilToDecimal(
+          assetBars.rowData.reduce(
+            (a, b) =>
+              b.priceDisabled
+                ? a + (b.borrow || 0) * b.price
+                : a + ((b.borrow || 0) * b.price * sliderPercentage * 2) / 100,
+            0
+          ),
+          2
+        )
+      )
+      scenarioHashMap.set(
+        'assets',
+        floorToDecimal(
+          assetBars.rowData.reduce(
+            (a, b) =>
+              b.priceDisabled
+                ? a + (b.deposit || 0) * b.price
+                : a + ((b.deposit || 0) * b.price * sliderPercentage * 2) / 100,
+            0
+          ),
+          2
+        )
+      )
+      scenarioHashMap.set(
+        'equity',
+        floorToDecimal(
+          scenarioHashMap.get('assets') - scenarioHashMap.get('liabilities'),
+          2
+        )
+      )
+      scenarioHashMap.set(
+        'leverage',
+        scenarioHashMap.get('liabilities') == 0
+          ? 0.0
+          : ceilToDecimal(
+              scenarioHashMap.get('liabilities') /
+                scenarioHashMap.get('equity'),
+              2
+            )
+      )
+      scenarioHashMap.set(
+        'collateralRatio',
+        scenarioHashMap.get('liabilities') == 0
+          ? 0
+          : floorToDecimal(
+              scenarioHashMap.get('assets') /
+                scenarioHashMap.get('liabilities') >
+                9.99
+                ? 999
+                : scenarioHashMap.get('liabilities') == 0
+                ? 0
+                : (scenarioHashMap.get('assets') /
+                    scenarioHashMap.get('liabilities')) *
+                  100,
+              0
+            )
+      )
+      scenarioHashMap.set(
+        'maintCollateralRatio',
+        floorToDecimal(selectedMangoGroup.maintCollRatio * 100, 0)
+      )
+      scenarioHashMap.set(
+        'percentToLiquidation',
+        scenarioHashMap.get('liabilities') == 0
+          ? 100
+          : floorToDecimal(
+              (1 -
+                (scenarioHashMap.get('liabilities') *
+                  scenarioHashMap.get('maintCollateralRatio')) /
+                  100 /
+                  scenarioHashMap.get('assets')) *
+                100,
+              0
+            )
+      )
+      scenarioHashMap.set(
+        'riskRanking',
+        scenarioHashMap.get('percentToLiquidation') < 15
+          ? 'High'
+          : scenarioHashMap.get('percentToLiquidation') < 35
+          ? 'Moderate'
+          : 'Low'
+      )
+      return scenarioHashMap
+    }
+  }
+
+  const scenarioDetails = getScenarioDetails()
 
   return (
     <div className={`bg-th-bkg-1 text-th-fgd-1 transition-all`}>
@@ -234,7 +263,7 @@ export default function LiquidationCalculator() {
             Liquidation Calculator
           </h1>
         </div>
-        {prices.length > 0 && !loading ? (
+        {connected && assetBars && !loading ? (
           <div className="rounded-lg bg-th-bkg-2">
             <div className="grid grid-cols-12">
               <div className="col-span-9 p-4">
@@ -261,7 +290,7 @@ export default function LiquidationCalculator() {
                     </div>
                     <Button
                       className={`text-xs flex items-center justify-center sm:ml-3 pt-0 pb-0 h-8 pl-3 pr-3 rounded`}
-                      onClick={() => resetAll()}
+                      onClick={() => initilizeScenario()}
                     >
                       <div className="flex items-center">
                         <RefreshIcon className="h-5 w-5 mr-1.5" />
@@ -291,7 +320,7 @@ export default function LiquidationCalculator() {
                               <div className="flex justify-between">
                                 Deposits
                                 <LinkButton
-                                  onClick={() => setDepositsInitialized(false)}
+                                  onClick={() => resetScenarioColumn('deposit')}
                                 >
                                   Reset
                                 </LinkButton>
@@ -304,7 +333,7 @@ export default function LiquidationCalculator() {
                               <div className="flex justify-between">
                                 Borrows
                                 <LinkButton
-                                  onClick={() => setBorrowsInitialized(false)}
+                                  onClick={() => resetScenarioColumn('borrow')}
                                 >
                                   Reset
                                 </LinkButton>
@@ -314,7 +343,7 @@ export default function LiquidationCalculator() {
                               <div className="flex justify-between">
                                 Price ($)
                                 <LinkButton
-                                  onClick={() => setPricesInitialized(false)}
+                                  onClick={() => resetScenarioColumn('price')}
                                 >
                                   Reset
                                 </LinkButton>
@@ -329,7 +358,7 @@ export default function LiquidationCalculator() {
                           </Tr>
                         </Thead>
                         <Tbody>
-                          {Object.entries(symbols).map(([name], i) => (
+                          {assetBars.rowData.map((asset, i) => (
                             <Tr key={`${i}`}>
                               <Td
                                 className={`px-3 py-2 whitespace-nowrap text-sm text-th-fgd-1`}
@@ -339,10 +368,10 @@ export default function LiquidationCalculator() {
                                     alt=""
                                     width="20"
                                     height="20"
-                                    src={`/assets/icons/${name.toLowerCase()}.svg`}
+                                    src={`/assets/icons/${asset.assetName.toLowerCase()}.svg`}
                                     className={`mr-2.5`}
                                   />
-                                  <div>{name}</div>
+                                  <div>{asset.assetName}</div>
                                 </div>
                               </Td>
                               <Td
@@ -350,9 +379,13 @@ export default function LiquidationCalculator() {
                               >
                                 <Input
                                   type="number"
-                                  value={getDeposit(i)}
+                                  value={asset.deposit}
                                   onChange={(e) =>
-                                    setDeposit(e.target.value, i)
+                                    updateScenarioValue(
+                                      asset.assetName,
+                                      'deposit',
+                                      e.target.value
+                                    )
                                   }
                                 />
                               </Td>
@@ -361,8 +394,14 @@ export default function LiquidationCalculator() {
                               >
                                 <Input
                                   type="number"
-                                  value={getBorrow(i)}
-                                  onChange={(e) => setBorrow(e.target.value, i)}
+                                  value={asset.borrow}
+                                  onChange={(e) =>
+                                    updateScenarioValue(
+                                      asset.assetName,
+                                      'borrow',
+                                      e.target.value
+                                    )
+                                  }
                                 />
                               </Td>
                               <Td
@@ -370,9 +409,20 @@ export default function LiquidationCalculator() {
                               >
                                 <Input
                                   type="number"
-                                  value={getPrice(i)}
-                                  onChange={(e) => setPrice(e.target.value, i)}
-                                  disabled={name === 'USDC' ? true : false}
+                                  value={
+                                    asset.priceDisabled
+                                      ? asset.price
+                                      : (asset.price * sliderPercentage * 2) /
+                                        100
+                                  }
+                                  onChange={(e) =>
+                                    updateScenarioValue(
+                                      asset.assetName,
+                                      'price',
+                                      e.target.value
+                                    )
+                                  }
+                                  disabled={asset.priceDisabled}
                                 />
                               </Td>
                               <Td
@@ -380,7 +430,11 @@ export default function LiquidationCalculator() {
                               >
                                 <Input
                                   type="text"
-                                  value={getCollateralWeight(i)}
+                                  value={
+                                    asset.priceDisabled
+                                      ? asset.net
+                                      : (asset.net * sliderPercentage * 2) / 100
+                                  }
                                   onChange={null}
                                   disabled
                                 />
@@ -393,71 +447,95 @@ export default function LiquidationCalculator() {
                   </div>
                 </div>
               </div>
-              <div className="bg-th-bkg-3 col-span-3 p-4 rounded-r-lg">
-                <div className="pb-4 text-th-fgd-1 text-lg">
-                  Scenario Details
-                </div>
-                <div className="flex items-center justify-between pb-3">
-                  <div className="text-th-fgd-3">Equity</div>
-                  <div className="font-bold">
-                    {`$${getScenarioEquity(depositValues, borrowValues)}`}
+              {connected && assetBars && !loading ? (
+                <div className="bg-th-bkg-3 col-span-3 p-4 rounded-r-lg">
+                  <div className="pb-4 text-th-fgd-1 text-lg">
+                    Scenario Details
                   </div>
-                </div>
-                <div className="flex items-center justify-between pb-3">
-                  <div className="text-th-fgd-3">Assets Value</div>
-                  <div className="font-bold">
-                    {`$${getScenarioAssets(depositValues)}`}
+                  <div className="flex items-center justify-between pb-3">
+                    <div className="text-th-fgd-3">Equity</div>
+                    <div className="font-bold">
+                      ${scenarioDetails.get('equity')}
+                    </div>
                   </div>
-                </div>
-                <div className="flex items-center justify-between pb-3">
-                  <div className="text-th-fgd-3">Liabilities Value</div>
-                  <div className="font-bold">
-                    {`$${getScenarioLiability(borrowValues)}`}
+                  <div className="flex items-center justify-between pb-3">
+                    <div className="text-th-fgd-3">Assets</div>
+                    <div className="font-bold">
+                      ${scenarioDetails.get('assets')}
+                    </div>
                   </div>
-                </div>
-                <div className="flex items-center justify-between pb-3">
-                  <div className="text-th-fgd-3">Leverage</div>
-                  <div className="font-bold">
-                    {`${getScenarioLeverage(depositValues, borrowValues)}x`}
+                  <div className="flex items-center justify-between pb-3">
+                    <div className="text-th-fgd-3">Liabilities</div>
+                    <div className="font-bold">
+                      ${scenarioDetails.get('liabilities')}
+                    </div>
                   </div>
-                </div>
-                <div className="flex items-center justify-between pb-3">
-                  <div className="text-th-fgd-3">Collateral Ratio</div>
-                  <div className="font-bold">
-                    {`${getScenarioCollateralRatio(
-                      depositValues,
-                      borrowValues
-                    )}%`}
-                  </div>
-                </div>
-                <div className="flex items-center justify-between pb-3">
-                  <div className="text-th-fgd-3">Min. Ratio Required</div>
-                  <div className="font-bold">110%</div>
-                </div>
-                <div className="flex items-center justify-between pb-3">
-                  <div className="text-th-fgd-3">Risk</div>
-                  {getScenarioCollateralRatio(depositValues, borrowValues) >
-                  150 ? (
-                    <div className="font-bold text-th-green">Low</div>
-                  ) : getScenarioCollateralRatio(depositValues, borrowValues) >
-                    125 ? (
-                    <div className="font-bold text-th-orange">Moderate</div>
+                  {scenarioDetails.get('liabilities') === 0 ? (
+                    <div className="flex items-center justify-center text-th-green pb-3">
+                      Account Safe: No Liabilities
+                    </div>
                   ) : (
-                    <div className="font-bold text-th-red">High</div>
+                    <div>
+                      <div className="flex items-center justify-between pb-3">
+                        <div className="text-th-fgd-3">Collateral Ratio</div>
+                        <div className="font-bold">
+                          {scenarioDetails.get('collateralRatio')}%
+                        </div>
+                      </div>
+                      <div className="flex items-center justify-between pb-3">
+                        <Tooltip content="The collateral ratio you must maintain to not get liquidated">
+                          <div className="text-th-fgd-3">MCR Required</div>
+                        </Tooltip>
+                        <div className="font-bold">
+                          {scenarioDetails.get('maintCollateralRatio')}%
+                        </div>
+                      </div>
+                      {scenarioDetails.get('collateralRatio') <=
+                      scenarioDetails.get('maintCollateralRatio') ? (
+                        <div className="flex items-center justify-center text-th-red pb-3">
+                          Account Liquidated
+                        </div>
+                      ) : (
+                        <div>
+                          <div className="flex items-center justify-between pb-3">
+                            <div className="text-th-fgd-3">Leverage</div>
+                            <div className="font-bold">
+                              {scenarioDetails.get('leverage')}x
+                            </div>
+                          </div>
+                          <div className="flex items-center justify-between pb-3">
+                            <div className="text-th-fgd-3">Risk</div>
+                            {
+                              <div
+                                className={`font-bold ${
+                                  scenarioDetails.get('riskRanking') === 'High'
+                                    ? 'text-th-red'
+                                    : scenarioDetails.get('riskRanking') ===
+                                      'Moderate'
+                                    ? 'text-th-orange'
+                                    : 'text-th-green'
+                                }`}
+                              >
+                                {scenarioDetails.get('riskRanking')}
+                              </div>
+                            }
+                          </div>
+                          <div className="flex items-center justify-between pb-3">
+                            <Tooltip content="The percentage move in total asset value which would result in the liquidation of your account.">
+                              <div className="text-th-fgd-3">
+                                Price Move To Liquidate
+                              </div>
+                            </Tooltip>
+                            <div className="font-bold">
+                              {scenarioDetails.get('percentToLiquidation')}%
+                            </div>
+                          </div>
+                        </div>
+                      )}
+                    </div>
                   )}
                 </div>
-                <div className="flex items-center justify-between pb-3">
-                  <Tooltip content="The percentage move in total assets value which would result in the liquidation of your account.">
-                    <div className="text-th-fgd-3">Price Move To Liquidate</div>
-                  </Tooltip>
-                  <div className="font-bold">
-                    {`${getLiquidationMovePercent(
-                      depositValues,
-                      borrowValues
-                    )}`}
-                  </div>
-                </div>
-              </div>
+              ) : null}
             </div>
           </div>
         ) : (

--- a/pages/liquidation-calculator.tsx
+++ b/pages/liquidation-calculator.tsx
@@ -96,27 +96,29 @@ export default function LiquidationCalculator() {
   }
 
   const updateScenarioValue = (assetName, field, val) => {
-    const updatedRowData = assetBars.rowData.map((asset) => {
-      if (asset.assetName == assetName) {
-        let updatedNet: number
-        switch (field) {
-          case 'deposit':
-            updatedNet = (val - asset.borrow) * asset.price
-            break
-          case 'borrow':
-            updatedNet = (asset.deposit - val) * asset.price
-            break
-          case 'price':
-            updatedNet = (asset.deposit - asset.borrow) * val
-            break
+    if (!Number.isNaN(val)) {
+      const updatedRowData = assetBars.rowData.map((asset) => {
+        if (asset.assetName == assetName) {
+          let updatedNet: number
+          switch (field) {
+            case 'deposit':
+              updatedNet = (Math.abs(val) - asset.borrow) * asset.price
+              break
+            case 'borrow':
+              updatedNet = (asset.deposit - Math.abs(val)) * asset.price
+              break
+            case 'price':
+              updatedNet = (asset.deposit - asset.borrow) * Math.abs(val)
+              break
+          }
+          return { ...asset, [field]: val, net: updatedNet }
+        } else {
+          return asset
         }
-        return { ...asset, [field]: val, net: updatedNet }
-      } else {
-        return asset
-      }
-    })
-    const updatedScenarioData = updateScenario(updatedRowData)
-    setAssetBars(updatedScenarioData)
+      })
+      const updatedScenarioData = updateScenario(updatedRowData)
+      setAssetBars(updatedScenarioData)
+    }
   }
 
   const resetScenarioColumn = (column) => {
@@ -168,8 +170,13 @@ export default function LiquidationCalculator() {
           assetBars.rowData.reduce(
             (a, b) =>
               b.priceDisabled
-                ? a + (b.borrow || 0) * b.price
-                : a + ((b.borrow || 0) * b.price * sliderPercentage * 2) / 100,
+                ? a + (Math.abs(b.borrow) || 0) * Math.abs(b.price)
+                : a +
+                  ((Math.abs(b.borrow) || 0) *
+                    Math.abs(b.price) *
+                    sliderPercentage *
+                    2) /
+                    100,
             0
           ),
           2
@@ -181,8 +188,13 @@ export default function LiquidationCalculator() {
           assetBars.rowData.reduce(
             (a, b) =>
               b.priceDisabled
-                ? a + (b.deposit || 0) * b.price
-                : a + ((b.deposit || 0) * b.price * sliderPercentage * 2) / 100,
+                ? a + (Math.abs(b.deposit) || 0) * Math.abs(b.price)
+                : a +
+                  ((Math.abs(b.deposit) || 0) *
+                    Math.abs(b.price) *
+                    sliderPercentage *
+                    2) /
+                    100,
             0
           ),
           2


### PR DESCRIPTION
Multiple updates from testing feedback, including:
- Updated handling of state by asset instead of action (BTC.deposit instead of deposit.BTC)
- Fixed slider percentage lag (was one state change behind)
- Cleaned up handling of scenario liquidation
- Handling of some dust borrows/NaN calculations found in testing
- Delaying update of state until a number is present (allows decimal place or sign to be entered).
- Convert user inputs into absolute values to avoid unwanted calculator output (such as a double negative).

https://user-images.githubusercontent.com/47860274/124699444-a12a4380-de9f-11eb-9145-9fe1d8107e19.mp4

