### PR TITLE
Display Order Lines on Chart

### DIFF
--- a/components/TradingView/index.tsx
+++ b/components/TradingView/index.tsx
@@ -6,12 +6,10 @@ import {
   IChartingLibraryWidget,
   ResolutionString,
 } from '../charting_library' // Make sure to follow step 1 of the README
-// import { useMarket } from '../../utils/markets';
 import { CHART_DATA_FEED } from '../../utils/chartDataConnector'
 import useMangoStore from '../../stores/useMangoStore'
 import { useOpenOrders } from '../../hooks/useOpenOrders'
 import { useSortableData } from '../../hooks/useSortableData'
-import { useState } from 'react'
 import { PublicKey } from '@solana/web3.js'
 import useConnection from '../../hooks/useConnection'
 import { cancelOrderAndSettle, modifyOrderAndSettle } from '../../utils/mango'
@@ -49,7 +47,6 @@ const TVChartContainer = () => {
   const selectedMarginAccount =
     useMangoStore.getState().selectedMarginAccount.current
   const selectedMarketPrice = useMangoStore((s) => s.selectedMarket.markPrice)
-  const [ordersLength, setOrdersLength] = useState(0)
 
   // @ts-ignore
   const defaultProps: ChartContainerProps = {
@@ -88,7 +85,6 @@ const TVChartContainer = () => {
         'limit'
       )
       actions.fetchMarginAccounts()
-      setOrdersLength(ordersLength - 1)
       return true
     } catch (e) {
       notify({
@@ -118,7 +114,6 @@ const TVChartContainer = () => {
         order
       )
       actions.fetchMarginAccounts()
-      setOrdersLength(ordersLength - 1)
       return true
     } catch (e) {
       notify({
@@ -302,11 +297,6 @@ const TVChartContainer = () => {
 
   useInterval(() => {
     markPrice = selectedMarketPrice
-    if (openOrders) {
-      setOrdersLength(openOrders.length)
-    } else {
-      setOrdersLength(-1)
-    }
   }, 500)
 
   useEffect(() => {
@@ -324,7 +314,7 @@ const TVChartContainer = () => {
         }
       })
     })
-  }, [ordersLength, selectedMarginAccount, connected, selectedMarketName])
+  }, [selectedMarginAccount, connected, selectedMarketName])
 
   return <div id={defaultProps.containerId} className="tradingview-chart" />
 }

--- a/components/TradingView/index.tsx
+++ b/components/TradingView/index.tsx
@@ -14,10 +14,8 @@ import { useSortableData } from '../../hooks/useSortableData'
 import { useState } from 'react'
 import { PublicKey } from '@solana/web3.js'
 import useConnection from '../../hooks/useConnection'
-import { placeAndSettle } from '../../utils/mango'
-import { cancelOrderAndSettle } from '../../utils/mango'
+import { cancelOrderAndSettle, modifyOrderAndSettle } from '../../utils/mango'
 import { notify } from '../../utils/notifications'
-import { IDS } from '@blockworks-foundation/mango-client'
 import useInterval from '../../hooks/useInterval'
 
 export interface ChartContainerProps {
@@ -36,7 +34,8 @@ export interface ChartContainerProps {
   theme: string
 }
 
-// export interface ChartContainerState {}
+const lines = new Map()
+let markPrice = 0
 
 const TVChartContainer = () => {
   const selectedMarketName = useMangoStore((s) => s.selectedMarket.name)
@@ -44,13 +43,13 @@ const TVChartContainer = () => {
   const openOrders = useOpenOrders()
   const { items } = useSortableData(openOrders)
 
-  const { connection, cluster, programId } = useConnection()
+  const { connection, programId } = useConnection()
   const actions = useMangoStore((s) => s.actions)
   const connected = useMangoStore((s) => s.wallet.connected)
-  const [ordersLength, setOrdersLength] = useState(0)
-  const [ordersDisplayed, setOrdersDisplayed] = useState([])
   const selectedMarginAccount =
     useMangoStore.getState().selectedMarginAccount.current
+  const selectedMarketPrice = useMangoStore((s) => s.selectedMarket.markPrice)
+  const [ordersLength, setOrdersLength] = useState(0)
 
   // @ts-ignore
   const defaultProps: ChartContainerProps = {
@@ -66,6 +65,40 @@ const TVChartContainer = () => {
       'volume.volume.color.0': theme === 'Mango' ? '#E54033' : '#CC2929',
       'volume.volume.color.1': theme === 'Mango' ? '#AFD803' : '#5EBF4D',
     },
+  }
+
+  const handleChangeOrder = async (order, newPrice) => {
+    const wallet = useMangoStore.getState().wallet.current
+    const selectedMangoGroup =
+      useMangoStore.getState().selectedMangoGroup.current
+
+    try {
+      if (!selectedMangoGroup || !selectedMarginAccount) return
+      await modifyOrderAndSettle(
+        connection,
+        new PublicKey(programId),
+        selectedMangoGroup,
+        selectedMarginAccount,
+        wallet,
+        order.market,
+        order,
+        order.side,
+        newPrice,
+        order.size,
+        'limit'
+      )
+      actions.fetchMarginAccounts()
+      setOrdersLength(ordersLength - 1)
+      return true
+    } catch (e) {
+      notify({
+        message: 'Error cancelling order',
+        description: e.message,
+        txid: e.txid,
+        type: 'error',
+      })
+      return false
+    }
   }
 
   const handleCancelOrder = async (order) => {
@@ -98,70 +131,7 @@ const TVChartContainer = () => {
     }
   }
 
-  const handlePlaceOrder = async (order, newPrice) => {
-    const marginAccount = useMangoStore.getState().selectedMarginAccount.current
-    const mangoGroup = useMangoStore.getState().selectedMangoGroup.current
-    const wallet = useMangoStore.getState().wallet.current
-
-    if (!mangoGroup || !marginAccount) return
-
-    try {
-      await placeAndSettle(
-        connection,
-        new PublicKey(IDS[cluster].mango_program_id),
-        mangoGroup,
-        marginAccount,
-        order.market,
-        wallet,
-        order.side,
-        newPrice,
-        order.size,
-        'postOnly'
-      )
-      actions.fetchMarginAccounts()
-      return true
-    } catch (e) {
-      notify({
-        message: 'Error placing order',
-        description: e.message,
-        txid: e.txid,
-        type: 'error',
-      })
-      return false
-    }
-  }
-
-  const handleChangeOrder = async (order, newPrice) => {
-    if (!order.price && !newPrice) {
-      notify({
-        message: 'Order and pricing information could not be retrieved',
-        type: 'error',
-      })
-      return false
-    }
-
-    try {
-      handleCancelOrder(order).then((res) => {
-        console.log('Message: ', res)
-        if (res) {
-          handlePlaceOrder(order, newPrice)
-        }
-      })
-      return true
-    } catch (e) {
-      notify({
-        message: 'Error changing order',
-        description: e.message,
-        txid: e.txid,
-        type: 'error',
-      })
-      return false
-    }
-  }
-
   const tvWidgetRef = useRef<IChartingLibraryWidget | null>(null)
-  // TODO: fetch market from store and wire up to chart
-  // const { market, marketName } = useMarket()
 
   useEffect(() => {
     const widgetOptions: ChartingLibraryWidgetOptions = {
@@ -229,128 +199,132 @@ const TVChartContainer = () => {
       },
     }
 
-    setOrdersDisplayed([])
     const tvWidget = new widget(widgetOptions)
     tvWidgetRef.current = tvWidget
+  }, [selectedMarketName, theme])
 
-    //eslint-disable-next-line
-  }, [selectedMarketName, theme, connected])
+  function getLine(order) {
+    return tvWidgetRef.current
+      .chart()
+      .createOrderLine({ disableUndo: false })
+      .onMove(function () {
+        this.setPrice(this.getPrice())
+        const currentOrderPrice = order.price
+        const updatedOrderPrice = this.getPrice()
 
-  useInterval(() => {
-    if (openOrders) {
-      setOrdersLength(openOrders.length)
-    } else {
-      setOrdersLength(0)
-    }
-  }, 250)
-
-  useEffect(() => {
-    if (ordersLength > 0 && openOrders != null) {
-      tvWidgetRef.current.onChartReady(() => {
-        if (openOrders != null) {
-          items.map((order) => {
-            if (ordersDisplayed.indexOf(order.orderId.toString()) == -1) {
-              console.log('orders: ', ordersDisplayed)
-
-              if (order.marketName == selectedMarketName) {
-                tvWidgetRef.current.chart().clearMarks()
-
-                tvWidgetRef.current
-                  .chart()
-                  .createOrderLine({ disableUndo: false })
-                  .onMove(function () {
-                    this.setPrice(this.getPrice())
-                    tvWidgetRef.current.showConfirmDialog({
-                      title: 'Change Order Price?',
-                      body: `Would you like to change your 
-                       ${order.size} ${order.marketName
-                        .split('/')[0]
-                        .toUpperCase()} ${order.side} at $${order.price} 
-                       to a
-                      ${order.size} ${order.marketName
-                        .split('/')[0]
-                        .toUpperCase()} ${order.side} at $${this.getPrice()} 
-                      (approve next 2 transactions)`,
-                      callback: (res) => {
-                        console.log('Change order: ', res)
-                        if (res) {
-                          handleChangeOrder(order, this.getPrice()).then(
-                            (result) => {
-                              if (result) {
-                                this.remove()
-                                setOrdersLength(openOrders.length)
-                              } else {
-                                this.setPrice(order.price)
-                              }
-                            }
-                          )
-                        } else {
-                          this.setPrice(order.price)
-                        }
-                      },
-                    })
-                  })
-                  .onCancel(function () {
-                    tvWidgetRef.current.showConfirmDialog({
-                      title: 'Cancel Your Order?',
-                      body: `Would you like to cancel your order for 
-                       ${order.size} ${order.marketName
-                        .split('/')[0]
-                        .toUpperCase()} ${order.side} at $${order.price}  
-                      (approve next transaction)`,
-                      callback: (res) => {
-                        if (res) {
-                          handleCancelOrder(order).then((res) => {
-                            if (res) {
-                              this.remove()
-                            }
-                          })
-                        }
-                      },
-                    })
-                  })
-                  .setText(
-                    `${order.side.toUpperCase()} ${order.marketName
-                      .split('/')[0]
-                      .toUpperCase()}`
-                  )
-                  .setBodyBorderColor(
-                    order.side == 'buy' ? '#AFD803' : '#E54033'
-                  )
-                  .setBodyBackgroundColor('#000000')
-                  .setBodyTextColor('#F2C94C')
-                  .setLineLength(3)
-                  .setLineColor(order.side == 'buy' ? '#AFD803' : '#E54033')
-                  .setQuantity(order.size)
-                  .setTooltip(`Order #: ${order.orderId}`)
-                  .setQuantityBorderColor(
-                    order.side == 'buy' ? '#AFD803' : '#E54033'
-                  )
-                  .setQuantityBackgroundColor('#000000')
-                  .setQuantityTextColor('#F2C94C')
-                  .setCancelButtonBorderColor(
-                    order.side == 'buy' ? '#AFD803' : '#E54033'
-                  )
-                  .setCancelButtonBackgroundColor('#000000')
-                  .setCancelButtonIconColor('#F2C94C')
-                  .setPrice(order.price)
-
-                //                  tvWidgetRef.current.chart().removeEntity(orderLine.entityId)
-                //                  orderLine.remove()
+        if (
+          (order.side === 'buy' && updatedOrderPrice > 1.05 * markPrice) ||
+          (order.side === 'sell' && updatedOrderPrice < 0.95 * markPrice)
+        ) {
+          tvWidgetRef.current.showNoticeDialog({
+            title: 'Order Price Outside Range',
+            body:
+              `Your order price ($${updatedOrderPrice.toFixed(
+                2
+              )}) is greater than 5% ${
+                order.side == 'buy' ? 'above' : 'below'
+              } the current market price ($${markPrice.toFixed(2)}). ` +
+              ' indicating you might incur significant slippage. <p><p>Please use the trade input form if you wish to accept the potential slippage.',
+            callback: () => {
+              this.setPrice(currentOrderPrice)
+            },
+          })
+          selectedMarketPrice
+        } else {
+          tvWidgetRef.current.showConfirmDialog({
+            title: 'Change Order Price?',
+            body: `Would you like to change your order from a 
+           ${order.size} ${order.marketName.split('/')[0].toUpperCase()} ${
+              order.side
+            } at $${currentOrderPrice} 
+           to a 
+          ${order.size} ${order.marketName.split('/')[0].toUpperCase()} ${
+              order.side
+            } at $${updatedOrderPrice} 
+          `,
+            callback: (res) => {
+              if (res) {
+                handleChangeOrder(order, updatedOrderPrice).then((result) => {
+                  if (result) {
+                    lines.delete(order.orderId.toString())
+                    this.remove()
+                  } else {
+                    this.setPrice(currentOrderPrice)
+                  }
+                })
+              } else {
+                this.setPrice(currentOrderPrice)
               }
-              setOrdersDisplayed((currentOrders) => [
-                ...currentOrders,
-                order.orderId.toString(),
-              ])
-            }
+            },
           })
         }
       })
-    }
-  }, [ordersLength])
+      .onCancel(function () {
+        tvWidgetRef.current.showConfirmDialog({
+          title: 'Cancel Your Order?',
+          body: `Would you like to cancel your order for 
+       ${order.size} ${order.marketName.split('/')[0].toUpperCase()} ${
+            order.side
+          } at $${order.price}  
+      `,
+          callback: (res) => {
+            if (res) {
+              handleCancelOrder(order).then((res) => {
+                if (res) {
+                  lines.delete(order.orderId.toString())
+                  this.remove()
+                }
+              })
+            }
+          },
+        })
+      })
+      .setText(
+        `${order.side.toUpperCase()} ${order.marketName
+          .split('/')[0]
+          .toUpperCase()}`
+      )
+      .setBodyBorderColor(order.side == 'buy' ? '#AFD803' : '#E54033')
+      .setBodyBackgroundColor('#000000')
+      .setBodyTextColor('#F2C94C')
+      .setLineLength(3)
+      .setLineColor(order.side == 'buy' ? '#AFD803' : '#E54033')
+      .setQuantity(order.size)
+      .setTooltip(`Order #: ${order.orderId}`)
+      .setQuantityBorderColor(order.side == 'buy' ? '#AFD803' : '#E54033')
+      .setQuantityBackgroundColor('#000000')
+      .setQuantityTextColor('#F2C94C')
+      .setCancelButtonBorderColor(order.side == 'buy' ? '#AFD803' : '#E54033')
+      .setCancelButtonBackgroundColor('#000000')
+      .setCancelButtonIconColor('#F2C94C')
+      .setPrice(order.price)
+  }
 
-  // TODO: add market back to dep array
-  // }, [market])
+  useInterval(() => {
+    markPrice = selectedMarketPrice
+    if (openOrders) {
+      setOrdersLength(openOrders.length)
+    } else {
+      setOrdersLength(-1)
+    }
+  }, 500)
+
+  useEffect(() => {
+    tvWidgetRef.current.onChartReady(() => {
+      if (lines.size > 0) {
+        lines.forEach((value, key) => {
+          lines.get(key).remove()
+          lines.delete(key)
+        })
+      }
+
+      items.map((order) => {
+        if (order.marketName == selectedMarketName) {
+          lines.set(order.orderId.toString(), getLine(order))
+        }
+      })
+    })
+  }, [ordersLength, selectedMarginAccount, connected, selectedMarketName])
 
   return <div id={defaultProps.containerId} className="tradingview-chart" />
 }

--- a/utils/mango.tsx
+++ b/utils/mango.tsx
@@ -1552,3 +1552,238 @@ export async function addMarginAccountInfo(
     'Add MarginAccount Info'
   )
 }
+
+export async function modifyOrderAndSettle(
+  connection: Connection,
+  programId: PublicKey,
+  mangoGroup: MangoGroup,
+  marginAccount: MarginAccount,
+  wallet: Wallet,
+  spotMarket: Market,
+  order: Order,
+  side: 'buy' | 'sell',
+  price: number,
+  size: number,
+  orderType?: 'limit' | 'ioc' | 'postOnly',
+  clientId?: BN
+): Promise<TransactionSignature> {
+  const transaction = new Transaction()
+
+  // CANCEL ORDER
+  let keys = [
+    { isSigner: false, isWritable: true, pubkey: mangoGroup.publicKey },
+    { isSigner: true, isWritable: false, pubkey: wallet.publicKey },
+    { isSigner: false, isWritable: true, pubkey: marginAccount.publicKey },
+    { isSigner: false, isWritable: false, pubkey: SYSVAR_CLOCK_PUBKEY },
+    { isSigner: false, isWritable: false, pubkey: mangoGroup.dexProgramId },
+    { isSigner: false, isWritable: true, pubkey: spotMarket.publicKey },
+    { isSigner: false, isWritable: true, pubkey: spotMarket['_decoded'].bids },
+    { isSigner: false, isWritable: true, pubkey: spotMarket['_decoded'].asks },
+    { isSigner: false, isWritable: true, pubkey: order.openOrdersAddress },
+    { isSigner: false, isWritable: false, pubkey: mangoGroup.signerKey },
+    {
+      isSigner: false,
+      isWritable: true,
+      pubkey: spotMarket['_decoded'].eventQueue,
+    },
+  ]
+
+  let data = encodeMangoInstruction({
+    CancelOrder: {
+      side: order.side,
+      orderId: order.orderId,
+    },
+  })
+  const instruction = new TransactionInstruction({ keys, data, programId })
+  transaction.add(instruction)
+
+  // MODIFY ORDER
+  orderType = orderType == undefined ? 'limit' : orderType
+
+  const limitPrice = spotMarket.priceNumberToLots(price)
+  const maxBaseQuantity = spotMarket.baseSizeNumberToLots(size)
+
+  const feeTier = getFeeTier(
+    0,
+    nativeToUi(mangoGroup.nativeSrm || 0, SRM_DECIMALS)
+  )
+  const rates = getFeeRates(feeTier)
+  const maxQuoteQuantity = new BN(
+    maxBaseQuantity
+      .mul(limitPrice)
+      .mul(spotMarket['_decoded'].quoteLotSize)
+      .toNumber() *
+      (1 + rates.taker)
+  )
+
+  console.log(maxBaseQuantity.toString(), maxQuoteQuantity.toString())
+
+  if (maxBaseQuantity.lte(new BN(0))) {
+    throw new Error('size too small')
+  }
+  if (limitPrice.lte(new BN(0))) {
+    throw new Error('invalid price')
+  }
+  const selfTradeBehavior = 'decrementTake'
+  const marketIndex = mangoGroup.getMarketIndex(spotMarket)
+
+  // Add all instructions to one atomic transaction
+  //  const transaction = new Transaction()
+
+  // Specify signers in addition to the wallet
+  const signers: Account[] = []
+
+  const dexSigner = await PublicKey.createProgramAddress(
+    [
+      spotMarket.publicKey.toBuffer(),
+      spotMarket['_decoded'].vaultSignerNonce.toArrayLike(Buffer, 'le', 8),
+    ],
+    spotMarket.programId
+  )
+
+  // Create a Solana account for the open orders account if it's missing
+  const openOrdersKeys: PublicKey[] = []
+  for (let i = 0; i < marginAccount.openOrders.length; i++) {
+    if (
+      i === marketIndex &&
+      marginAccount.openOrders[marketIndex].equals(zeroKey)
+    ) {
+      // open orders missing for this market; create a new one now
+      const openOrdersSpace = OpenOrders.getLayout(mangoGroup.dexProgramId).span
+      const openOrdersLamports =
+        await connection.getMinimumBalanceForRentExemption(
+          openOrdersSpace,
+          'singleGossip'
+        )
+      const accInstr = await createAccountInstruction(
+        connection,
+        wallet.publicKey,
+        openOrdersSpace,
+        mangoGroup.dexProgramId,
+        openOrdersLamports
+      )
+
+      transaction.add(accInstr.instruction)
+      signers.push(accInstr.account)
+      openOrdersKeys.push(accInstr.account.publicKey)
+    } else {
+      openOrdersKeys.push(marginAccount.openOrders[i])
+    }
+  }
+
+  // Only send a pre-settle instruction if open orders account already exists
+  if (!marginAccount.openOrders[marketIndex].equals(zeroKey)) {
+    const settleFundsInstr = makeSettleFundsInstruction(
+      programId,
+      mangoGroup.publicKey,
+      wallet.publicKey,
+      marginAccount.publicKey,
+      spotMarket.programId,
+      spotMarket.publicKey,
+      openOrdersKeys[marketIndex],
+      mangoGroup.signerKey,
+      spotMarket['_decoded'].baseVault,
+      spotMarket['_decoded'].quoteVault,
+      mangoGroup.vaults[marketIndex],
+      mangoGroup.vaults[NUM_TOKENS - 1],
+      dexSigner
+    )
+    transaction.add(settleFundsInstr)
+  }
+
+  keys = [
+    { isSigner: false, isWritable: true, pubkey: mangoGroup.publicKey },
+    { isSigner: true, isWritable: false, pubkey: wallet.publicKey },
+    { isSigner: false, isWritable: true, pubkey: marginAccount.publicKey },
+    { isSigner: false, isWritable: false, pubkey: SYSVAR_CLOCK_PUBKEY },
+    { isSigner: false, isWritable: false, pubkey: spotMarket.programId },
+    { isSigner: false, isWritable: true, pubkey: spotMarket.publicKey },
+    {
+      isSigner: false,
+      isWritable: true,
+      pubkey: spotMarket['_decoded'].requestQueue,
+    },
+    {
+      isSigner: false,
+      isWritable: true,
+      pubkey: spotMarket['_decoded'].eventQueue,
+    },
+    { isSigner: false, isWritable: true, pubkey: spotMarket['_decoded'].bids },
+    { isSigner: false, isWritable: true, pubkey: spotMarket['_decoded'].asks },
+    {
+      isSigner: false,
+      isWritable: true,
+      pubkey: mangoGroup.vaults[marketIndex],
+    },
+    {
+      isSigner: false,
+      isWritable: true,
+      pubkey: mangoGroup.vaults[NUM_TOKENS - 1],
+    },
+    { isSigner: false, isWritable: false, pubkey: mangoGroup.signerKey },
+    {
+      isSigner: false,
+      isWritable: true,
+      pubkey: spotMarket['_decoded'].baseVault,
+    },
+    {
+      isSigner: false,
+      isWritable: true,
+      pubkey: spotMarket['_decoded'].quoteVault,
+    },
+    { isSigner: false, isWritable: false, pubkey: TOKEN_PROGRAM_ID },
+    { isSigner: false, isWritable: false, pubkey: SYSVAR_RENT_PUBKEY },
+    { isSigner: false, isWritable: true, pubkey: mangoGroup.srmVault },
+    { isSigner: false, isWritable: false, pubkey: dexSigner },
+    ...openOrdersKeys.map((pubkey) => ({
+      isSigner: false,
+      isWritable: true,
+      pubkey,
+    })),
+    ...mangoGroup.oracles.map((pubkey) => ({
+      isSigner: false,
+      isWritable: false,
+      pubkey,
+    })),
+  ]
+
+  data = encodeMangoInstruction({
+    PlaceAndSettle: clientId
+      ? {
+          side,
+          limitPrice,
+          maxBaseQuantity,
+          maxQuoteQuantity,
+          selfTradeBehavior,
+          orderType,
+          clientId,
+          limit: 65535,
+        }
+      : {
+          side,
+          limitPrice,
+          maxBaseQuantity,
+          maxQuoteQuantity,
+          selfTradeBehavior,
+          orderType,
+          limit: 65535,
+        },
+  })
+
+  const placeAndSettleInstruction = new TransactionInstruction({
+    keys,
+    data,
+    programId,
+  })
+  transaction.add(placeAndSettleInstruction)
+  //}
+  //}
+
+  return await packageAndSend(
+    transaction,
+    connection,
+    wallet,
+    signers,
+    'place change order and settle'
+  )
+}


### PR DESCRIPTION
Display of lines for each order in the current market for a connected account, as well as the ability to cancel the order, and the ability to modify the order price by dragging the line and confirming.

Added a modify order function to allow change orders to be completed in one transaction.

Demo below:

https://user-images.githubusercontent.com/47860274/127901490-b2911239-bb54-42a7-8418-147d994de2e0.mp4

Please let me know any feedback.